### PR TITLE
plain-kube-secret-client

### DIFF
--- a/pkg/api/v1/clients/factory/resource_client_factory.go
+++ b/pkg/api/v1/clients/factory/resource_client_factory.go
@@ -1,6 +1,7 @@
 package factory
 
 import (
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kubesecretplain"
 	"reflect"
 	"strings"
 
@@ -61,6 +62,9 @@ func newResourceClient(factory ResourceClientFactory, params NewResourceClientPa
 	case *KubeConfigMapClientFactory:
 		return configmap.NewResourceClient(opts.Clientset, resourceType)
 	case *KubeSecretClientFactory:
+		if opts.PlainSecrets {
+			return kubesecretplain.NewResourceClient(opts.Clientset, resourceType)
+		}
 		return kubesecret.NewResourceClient(opts.Clientset, resourceType)
 	case *VaultSecretClientFactory:
 		return vault.NewResourceClient(opts.Vault, opts.RootKey, resourceType), nil
@@ -118,6 +122,9 @@ func (f *KubeConfigMapClientFactory) NewResourceClient(params NewResourceClientP
 
 type KubeSecretClientFactory struct {
 	Clientset kubernetes.Interface
+	// set this  to true if resource fields are all strings
+	// resources will be stored as plain kubernetes secrets without serializing/deserializing
+	PlainSecrets bool
 }
 
 func (f *KubeSecretClientFactory) NewResourceClient(params NewResourceClientParams) (clients.ResourceClient, error) {

--- a/pkg/api/v1/clients/kubesecretplain/kubesecret_suite_test.go
+++ b/pkg/api/v1/clients/kubesecretplain/kubesecret_suite_test.go
@@ -1,0 +1,13 @@
+package kubesecretplain_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestKubesecret(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kubesecret Suite")
+}

--- a/pkg/api/v1/clients/kubesecretplain/resource_client.go
+++ b/pkg/api/v1/clients/kubesecretplain/resource_client.go
@@ -1,0 +1,265 @@
+package kubesecretplain
+
+import (
+	"reflect"
+	"sort"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+	"github.com/solo-io/solo-kit/pkg/errors"
+	"github.com/solo-io/solo-kit/pkg/utils/kubeutils"
+	"github.com/solo-io/solo-kit/pkg/utils/protoutils"
+	"k8s.io/api/core/v1"
+	apiexts "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	kubewatch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+// KubeClient for raw secrets, e.g. only map[string]string
+// TODO: merge this with kubesecret client
+const annotationKey = "resource_kind"
+
+func (rc *ResourceClient) fromKubeSecret(secret *v1.Secret) (resources.Resource, error) {
+	resource := rc.NewResource()
+	// not our secret
+	// should be an error on a Read, ignored on a list
+	if len(secret.ObjectMeta.Annotations) == 0 || secret.ObjectMeta.Annotations[annotationKey] != rc.Kind() {
+		return nil, nil
+	}
+	// only works for string fields
+	resourceMap := make(map[string]interface{})
+	for k, v := range secret.Data {
+		resourceMap[k] = v
+	}
+	if err := protoutils.UnmarshalMap(resourceMap, resource); err != nil {
+		return nil, errors.Wrapf(err, "reading secret data into %v", rc.Kind())
+	}
+	resource.SetMetadata(kubeutils.FromKubeMeta(secret.ObjectMeta))
+	return resource, nil
+}
+
+func (rc *ResourceClient) toKubeSecret(resource resources.Resource) (*v1.Secret, error) {
+	resourceMap, err := protoutils.MarshalMapEmitZeroValues(resource)
+	if err != nil {
+		return nil, errors.Wrapf(err, "marshalling resource as map")
+	}
+	kubeSecretData := make(map[string][]byte)
+	for k, v := range resourceMap {
+		switch val := v.(type) {
+		case []byte:
+			kubeSecretData[k] = val
+		case string:
+			kubeSecretData[k] = []byte(val)
+		default:
+			// TODO: handle other field types; for now the caller
+			// must know this resource client only supports map[string]string style objects
+		}
+	}
+
+	meta := kubeutils.ToKubeMeta(resource.GetMetadata())
+	if meta.Annotations == nil {
+		meta.Annotations = make(map[string]string)
+	}
+	meta.Annotations[annotationKey] = rc.Kind()
+	return &v1.Secret{
+		ObjectMeta: meta,
+		Data:       kubeSecretData,
+	}, nil
+}
+
+type ResourceClient struct {
+	apiexts      apiexts.Interface
+	kube         kubernetes.Interface
+	ownerLabel   string
+	resourceName string
+	resourceType resources.Resource
+}
+
+func NewResourceClient(kube kubernetes.Interface, resourceType resources.Resource) (*ResourceClient, error) {
+	return &ResourceClient{
+		kube:         kube,
+		resourceName: reflect.TypeOf(resourceType).String(),
+		resourceType: resourceType,
+	}, nil
+}
+
+var _ clients.ResourceClient = &ResourceClient{}
+
+func (rc *ResourceClient) Kind() string {
+	return resources.Kind(rc.resourceType)
+}
+
+func (rc *ResourceClient) NewResource() resources.Resource {
+	return resources.Clone(rc.resourceType)
+}
+
+func (rc *ResourceClient) Register() error {
+	return nil
+}
+
+func (rc *ResourceClient) Read(namespace, name string, opts clients.ReadOpts) (resources.Resource, error) {
+	if err := resources.ValidateName(name); err != nil {
+		return nil, errors.Wrapf(err, "validation error")
+	}
+	opts = opts.WithDefaults()
+	namespace = clients.DefaultNamespaceIfEmpty(namespace)
+
+	secret, err := rc.kube.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, errors.NewNotExistErr(namespace, name, err)
+		}
+		return nil, errors.Wrapf(err, "reading secret from kubernetes")
+	}
+	resource, err := rc.fromKubeSecret(secret)
+	if err != nil {
+		return nil, err
+	}
+	if resource == nil {
+		return nil, errors.Errorf("secret %v is not kind %v", name, rc.Kind())
+	}
+	return resource, nil
+}
+
+func (rc *ResourceClient) Write(resource resources.Resource, opts clients.WriteOpts) (resources.Resource, error) {
+	opts = opts.WithDefaults()
+	if err := resources.Validate(resource); err != nil {
+		return nil, errors.Wrapf(err, "validation error")
+	}
+	meta := resource.GetMetadata()
+	meta.Namespace = clients.DefaultNamespaceIfEmpty(meta.Namespace)
+
+	// mutate and return clone
+	clone := proto.Clone(resource).(resources.Resource)
+	clone.SetMetadata(meta)
+	secret, err := rc.toKubeSecret(resource.(resources.Resource))
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := rc.Read(meta.Namespace, meta.Name, clients.ReadOpts{
+		Ctx: opts.Ctx,
+	})
+	if original != nil && err == nil {
+		if !opts.OverwriteExisting {
+			return nil, errors.NewExistErr(meta)
+		}
+		if meta.ResourceVersion != original.GetMetadata().ResourceVersion {
+			return nil, errors.NewResourceVersionErr(meta.Namespace, meta.Name, meta.ResourceVersion, original.GetMetadata().ResourceVersion)
+		}
+		if _, err := rc.kube.CoreV1().Secrets(secret.Namespace).Update(secret); err != nil {
+			return nil, errors.Wrapf(err, "updating kube secret %v", secret.Name)
+		}
+	} else {
+		if _, err := rc.kube.CoreV1().Secrets(secret.Namespace).Create(secret); err != nil {
+			return nil, errors.Wrapf(err, "creating kube secret %v", secret.Name)
+		}
+	}
+
+	// return a read object to update the resource version
+	return rc.Read(secret.Namespace, secret.Name, clients.ReadOpts{Ctx: opts.Ctx})
+}
+
+func (rc *ResourceClient) Delete(namespace, name string, opts clients.DeleteOpts) error {
+	opts = opts.WithDefaults()
+	if !rc.exist(namespace, name) {
+		if !opts.IgnoreNotExist {
+			return errors.NewNotExistErr(namespace, name)
+		}
+		return nil
+	}
+
+	if err := rc.kube.CoreV1().Secrets(namespace).Delete(name, nil); err != nil {
+		return errors.Wrapf(err, "deleting secret %v", name)
+	}
+	return nil
+}
+
+func (rc *ResourceClient) List(namespace string, opts clients.ListOpts) (resources.ResourceList, error) {
+	opts = opts.WithDefaults()
+	namespace = clients.DefaultNamespaceIfEmpty(namespace)
+
+	secretList, err := rc.kube.CoreV1().Secrets(namespace).List(metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(opts.Selector).String(),
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "listing secrets in %v", namespace)
+	}
+	var resourceList resources.ResourceList
+	for _, secret := range secretList.Items {
+		resource, err := rc.fromKubeSecret(&secret)
+		if err != nil {
+			return nil, err
+		}
+		// not our resource, ignore it
+		if resource == nil {
+			continue
+		}
+		resourceList = append(resourceList, resource)
+	}
+
+	sort.SliceStable(resourceList, func(i, j int) bool {
+		return resourceList[i].GetMetadata().Name < resourceList[j].GetMetadata().Name
+	})
+
+	return resourceList, nil
+}
+
+func (rc *ResourceClient) Watch(namespace string, opts clients.WatchOpts) (<-chan resources.ResourceList, <-chan error, error) {
+	opts = opts.WithDefaults()
+	namespace = clients.DefaultNamespaceIfEmpty(namespace)
+	watch, err := rc.kube.CoreV1().Secrets(namespace).Watch(metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(opts.Selector).String(),
+	})
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "initiating kube watch in %v", namespace)
+	}
+	resourcesChan := make(chan resources.ResourceList)
+	errs := make(chan error)
+	updateResourceList := func() {
+		list, err := rc.List(namespace, clients.ListOpts{
+			Ctx:      opts.Ctx,
+			Selector: opts.Selector,
+		})
+		if err != nil {
+			errs <- err
+			return
+		}
+		resourcesChan <- list
+	}
+
+	go func() {
+		// watch should open up with an initial read
+		updateResourceList()
+		for {
+			select {
+			case <-time.After(opts.RefreshRate):
+				updateResourceList()
+			case event := <-watch.ResultChan():
+				switch event.Type {
+				case kubewatch.Error:
+					errs <- errors.Errorf("error during watch: %v", event)
+				default:
+					updateResourceList()
+				}
+			case <-opts.Ctx.Done():
+				watch.Stop()
+				close(resourcesChan)
+				close(errs)
+				return
+			}
+		}
+	}()
+
+	return resourcesChan, errs, nil
+}
+
+func (rc *ResourceClient) exist(namespace, name string) bool {
+	_, err := rc.kube.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+	return err == nil
+}

--- a/pkg/api/v1/clients/kubesecretplain/resource_client_test.go
+++ b/pkg/api/v1/clients/kubesecretplain/resource_client_test.go
@@ -1,0 +1,75 @@
+package kubesecretplain_test
+
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/solo-io/solo-kit/test/mocks/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/solo-io/solo-kit/pkg/api/v1/clients/kubesecretplain"
+	"github.com/solo-io/solo-kit/pkg/utils/log"
+	"github.com/solo-io/solo-kit/test/helpers"
+	"github.com/solo-io/solo-kit/test/setup"
+	"github.com/solo-io/solo-kit/test/tests/generic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var _ = Describe("Base", func() {
+	if os.Getenv("RUN_KUBE_TESTS") != "1" {
+		log.Printf("This test creates kubernetes resources and is disabled by default. To enable, set RUN_KUBE_TESTS=1 in your env.")
+		return
+	}
+	var (
+		namespace string
+		cfg       *rest.Config
+		client    *ResourceClient
+		kube      kubernetes.Interface
+	)
+	BeforeEach(func() {
+		namespace = helpers.RandString(8)
+		err := setup.SetupKubeForTest(namespace)
+		Expect(err).NotTo(HaveOccurred())
+		kubeconfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
+		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		Expect(err).NotTo(HaveOccurred())
+		kube, err = kubernetes.NewForConfig(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		client, err = NewResourceClient(kube, &v1.MockResource{})
+	})
+	AfterEach(func() {
+		setup.TeardownKube(namespace)
+	})
+	It("CRUDs resources", func() {
+		generic.TestCrudClient(namespace, client, time.Minute)
+	})
+	It("does not escape string fields", func() {
+		foo := "test-data-keys"
+		input := v1.NewMockResource(namespace, foo)
+		data := "hello: goodbye"
+		input.Data = data
+		labels := map[string]string{"pick": "me"}
+		input.Metadata.Labels = labels
+
+		err := client.Register()
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = client.Write(input, clients.WriteOpts{})
+		Expect(err).NotTo(HaveOccurred())
+
+		cm, err := kube.CoreV1().Secrets(input.Metadata.Namespace).Get(input.Metadata.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cm.Data).To(HaveKey("data.json"))
+		Expect(cm.Data["data.json"]).To(ContainSubstring("'hello: goodbye'"))
+		Expect(cm.Data["data.json"]).To(Equal("hello: goodbye\n"))
+	})
+	// no string escape
+})

--- a/pkg/api/v1/clients/kubesecretplain/resource_client_test.go
+++ b/pkg/api/v1/clients/kubesecretplain/resource_client_test.go
@@ -68,8 +68,7 @@ var _ = Describe("Base", func() {
 		cm, err := kube.CoreV1().Secrets(input.Metadata.Namespace).Get(input.Metadata.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cm.Data).To(HaveKey("data.json"))
-		Expect(cm.Data["data.json"]).To(ContainSubstring("'hello: goodbye'"))
-		Expect(cm.Data["data.json"]).To(Equal("hello: goodbye\n"))
+		Expect(string(cm.Data["data.json"])).To(Equal("hello: goodbye"))
 	})
 	// no string escape
 })

--- a/pkg/api/v1/clients/kubesecretplain/resource_client_test.go
+++ b/pkg/api/v1/clients/kubesecretplain/resource_client_test.go
@@ -70,5 +70,23 @@ var _ = Describe("Base", func() {
 		Expect(cm.Data).To(HaveKey("data.json"))
 		Expect(string(cm.Data["data.json"])).To(Equal("hello: goodbye"))
 	})
+	It("emits empty fields", func() {
+		foo := "test-data-keys"
+		input := v1.NewMockResource(namespace, foo)
+		data := ""
+		input.Data = data
+		labels := map[string]string{"pick": "me"}
+		input.Metadata.Labels = labels
+
+		err := client.Register()
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = client.Write(input, clients.WriteOpts{})
+		Expect(err).NotTo(HaveOccurred())
+
+		cm, err := kube.CoreV1().Secrets(input.Metadata.Namespace).Get(input.Metadata.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cm.Data).To(HaveKey("data.json"))
+	})
 	// no string escape
 })

--- a/pkg/utils/protoutils/marshal.go
+++ b/pkg/utils/protoutils/marshal.go
@@ -16,11 +16,22 @@ import (
 )
 
 var jsonpbMarshaler = &jsonpb.Marshaler{OrigName: false}
+var jsonpbMarshalerEmitZeroValues = &jsonpb.Marshaler{OrigName: false, EmitDefaults: true}
 
 // this function is designed for converting go object (that is not a proto.Message) into a
 // pb Struct, based on json struct tags
 func MarshalStruct(m proto.Message) (*types.Struct, error) {
 	data, err := MarshalBytes(m)
+	if err != nil {
+		return nil, err
+	}
+	var pb types.Struct
+	err = jsonpb.UnmarshalString(string(data), &pb)
+	return &pb, err
+}
+
+func MarshalStructEmitZeroValues(m proto.Message) (*types.Struct, error) {
+	data, err := MarshalBytesEmitZeroValues(m)
 	if err != nil {
 		return nil, err
 	}
@@ -60,8 +71,24 @@ func MarshalBytes(pb proto.Message) ([]byte, error) {
 	return buf.Bytes(), err
 }
 
+func MarshalBytesEmitZeroValues(pb proto.Message) ([]byte, error) {
+	buf := &bytes.Buffer{}
+	err := jsonpbMarshalerEmitZeroValues.Marshal(buf, pb)
+	return buf.Bytes(), err
+}
+
 func MarshalMap(from proto.Message) (map[string]interface{}, error) {
 	data, err := MarshalBytes(from)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]interface{}
+	err = json.Unmarshal(data, &m)
+	return m, err
+}
+
+func MarshalMapEmitZeroValues(from proto.Message) (map[string]interface{}, error) {
+	data, err := MarshalBytesEmitZeroValues(from)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
adds a new base resource client to solo-kit which does not attempt 
to marshal/unmarshal resources as JSON when they are stored 
as kubernetes secrets. this allows support in solo-kit
 for resource clients compatible with traditional ("plain") 
kubernetes secrets