### PR TITLE
Allow for kube clients to skip CRD creation

### DIFF
--- a/pkg/api/v1/clients/client_interface.go
+++ b/pkg/api/v1/clients/client_interface.go
@@ -19,6 +19,7 @@ func DefaultNamespaceIfEmpty(namespace string) string {
 	return namespace
 }
 
+// TODO(marco): the 'register' method is implemented only by the kube resource client. Maybe we should remove it from the interface
 type ResourceClient interface {
 	Kind() string
 	NewResource() resources.Resource

--- a/pkg/api/v1/clients/factory/resource_client_factory.go
+++ b/pkg/api/v1/clients/factory/resource_client_factory.go
@@ -53,7 +53,7 @@ func newResourceClient(factory ResourceClientFactory, params NewResourceClientPa
 		if opts.Cfg == nil {
 			return nil, errors.Errorf("must provide a resclient.Config for the kube resource client")
 		}
-		return kube.NewResourceClient(opts.Crd, opts.Cfg, opts.SharedCache, inputResource)
+		return kube.NewResourceClient(opts.Crd, opts.Cfg, opts.SharedCache, inputResource, opts.SkipCrdCreation)
 	case *ConsulResourceClientFactory:
 		return consul.NewResourceClient(opts.Consul, opts.RootKey, resourceType), nil
 	case *FileResourceClientFactory:
@@ -78,10 +78,14 @@ type ResourceClientFactory interface {
 	NewResourceClient(params NewResourceClientParams) (clients.ResourceClient, error)
 }
 
+// If SkipCrdCreation is set to 'true', the clients built with this factory will not attempt to create the given CRD
+// during registration. This allows us to create and register resource clients in cases where the given configuration
+// contains a token associated with a user that is not authorized to create CRDs.
 type KubeResourceClientFactory struct {
-	Crd         crd.Crd
-	Cfg         *rest.Config
-	SharedCache *kube.KubeCache
+	Crd             crd.Crd
+	Cfg             *rest.Config
+	SharedCache     *kube.KubeCache
+	SkipCrdCreation bool
 }
 
 func (f *KubeResourceClientFactory) NewResourceClient(params NewResourceClientParams) (clients.ResourceClient, error) {


### PR DESCRIPTION
We want to be able to build kubernetes clients for users (tokens) with limited privileges. Currently, the `Register` method tries to create CRDs and fails in case the user is not authorized to perform that action. I added a `skipCrdCreation` bool field to the kube factory to allow for this action to be skipped. The bool's zero value makes this change backwards compatible.