### PR TITLE
Import GCP auth

### DIFF
--- a/test/tests/typed/typed_rc_tester.go
+++ b/test/tests/typed/typed_rc_tester.go
@@ -15,6 +15,10 @@ import (
 	"github.com/solo-io/solo-kit/test/setup"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+
+	// From https://github.com/kubernetes/client-go/blob/53c7adfd0294caa142d961e1f780f74081d5b15f/examples/out-of-cluster-client-configuration/main.go#L31
+	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 type ResourceClientTester interface {


### PR DESCRIPTION
Required for running auto-generated tests against google cloud, blocker for solo-io/gloo#188