### PR TITLE
Update template2

### DIFF
--- a/pkg/code-generator/codegen/templates/resource_ciient_test_template.go
+++ b/pkg/code-generator/codegen/templates/resource_ciient_test_template.go
@@ -4,9 +4,9 @@ import (
 	"text/template"
 )
 
-var ResourceClientTestTemplate = template.Must(template.New("resource_client_test").Funcs(Funcs).Parse(`package {{ .Project.Version }}
+var ResourceClientTestTemplate = template.Must(template.New("resource_client_test").Funcs(Funcs).Parse(`// +build solokit
 
-// +build solokit
+package {{ .Project.Version }}
 
 import (
 	"time"

--- a/pkg/code-generator/codegen/templates/snapshot_emitter_test_template.go
+++ b/pkg/code-generator/codegen/templates/snapshot_emitter_test_template.go
@@ -35,6 +35,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 {{- if $needs_kube_client }}
 	"k8s.io/client-go/kubernetes"
+    
+    // From https://github.com/kubernetes/client-go/blob/53c7adfd0294caa142d961e1f780f74081d5b15f/examples/out-of-cluster-client-configuration/main.go#L31
+	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 {{- end }}
 )
 

--- a/pkg/code-generator/codegen/templates/snapshot_emitter_test_template.go
+++ b/pkg/code-generator/codegen/templates/snapshot_emitter_test_template.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/client-go/kubernetes"
     
     // From https://github.com/kubernetes/client-go/blob/53c7adfd0294caa142d961e1f780f74081d5b15f/examples/out-of-cluster-client-configuration/main.go#L31
-	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 {{- end }}
 )


### PR DESCRIPTION
My last fix was incorrect, I assumed since the test run was faster the tests were properly ignored, actually I missed this error in the logs: 

Step #3: projects/gateway/pkg/api/v1/gateway_client_test.go:5: +build comment must appear before package clause and be followed by a blank line
