### PR TITLE
remove pinned fork override, point imports to fork

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -334,6 +334,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:37fe5a9adb37233d7f2d764dcdef5e2537d0d927bf57a6095f178817c8c616e5"
+  name = "github.com/ilackarms/protokit"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "7037620bf27b13fcdc10b1b17ddef82540db670b"
+  version = "v0.1.0"
+
+[[projects]]
   digest = "1:3e260afa138eab6492b531a3b3d10ab4cb70512d423faa78b8949dec76e66a21"
   name = "github.com/imdario/mergo"
   packages = ["."]
@@ -553,15 +561,6 @@
   pruneopts = "UT"
   revision = "728a624b38e5ae90bb3e5da5f406e05138f1517c"
   version = "v1.0.0"
-
-[[projects]]
-  branch = "switch-to-gogo"
-  digest = "1:cc234d93acf845c2abff6bf4ed3af8d29a21ffe366128daa829ee9416904306d"
-  name = "github.com/pseudomuto/protokit"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "5771174811e795f5862a0d8fc55f22b1bb27abc2"
-  source = "https://github.com/ilackarms/protokit"
 
 [[projects]]
   digest = "1:0665976cc6d8c2e60dafca32820b6b7eca70f37ded0bcccc103388e1c0d05c53"
@@ -1040,12 +1039,12 @@
     "github.com/hashicorp/vault/api",
     "github.com/iancoleman/strcase",
     "github.com/ilackarms/protoc-gen-doc",
+    "github.com/ilackarms/protokit",
     "github.com/k0kubun/pp",
     "github.com/mitchellh/hashstructure",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
     "github.com/pkg/errors",
-    "github.com/pseudomuto/protokit",
     "github.com/radovskyb/watcher",
     "go.opencensus.io/exporter/prometheus",
     "go.opencensus.io/stats",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,11 +48,6 @@
   version = "1.2.0"
   name = "github.com/golang/protobuf"
 
-[[constraint]]
-  branch = "switch-to-gogo"
-  source = "https://github.com/ilackarms/protokit"
-  name = "github.com/pseudomuto/protokit"
-
 #[[constraint]]
 #  revision = "e9c5d9645c437ab1b204cff969a2c0fb16cd4276"
 #  name = "github.com/grpc-ecosystem/go-grpc-middleware"

--- a/pkg/code-generator/codegen/funcs/template_funcs.go
+++ b/pkg/code-generator/codegen/funcs/template_funcs.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	"github.com/iancoleman/strcase"
 	"github.com/ilackarms/protoc-gen-doc"
-	"github.com/pseudomuto/protokit"
+	"github.com/ilackarms/protokit"
 	"github.com/solo-io/solo-kit/pkg/code-generator/model"
 	"github.com/solo-io/solo-kit/pkg/errors"
 )

--- a/pkg/code-generator/codegen/templates/funcs.go
+++ b/pkg/code-generator/codegen/templates/funcs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	"github.com/iancoleman/strcase"
 	"github.com/ilackarms/protoc-gen-doc"
-	"github.com/pseudomuto/protokit"
+	"github.com/ilackarms/protokit"
 )
 
 var primitiveTypes = map[descriptor.FieldDescriptorProto_Type]string{

--- a/pkg/code-generator/docgen/generator.go
+++ b/pkg/code-generator/docgen/generator.go
@@ -5,7 +5,7 @@ import (
 	"text/template"
 
 	"github.com/iancoleman/strcase"
-	"github.com/pseudomuto/protokit"
+	"github.com/ilackarms/protokit"
 	"github.com/solo-io/solo-kit/pkg/code-generator"
 	"github.com/solo-io/solo-kit/pkg/code-generator/docgen/templates"
 	"github.com/solo-io/solo-kit/pkg/code-generator/model"

--- a/pkg/code-generator/model/project.go
+++ b/pkg/code-generator/model/project.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
-	"github.com/pseudomuto/protokit"
+	"github.com/ilackarms/protokit"
 	"github.com/solo-io/solo-kit/pkg/errors"
 )
 

--- a/pkg/code-generator/parser/parser.go
+++ b/pkg/code-generator/parser/parser.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 	"github.com/iancoleman/strcase"
-	"github.com/pseudomuto/protokit"
+	"github.com/ilackarms/protokit"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	"github.com/solo-io/solo-kit/pkg/code-generator/model"
 	"github.com/solo-io/solo-kit/pkg/utils/log"

--- a/pkg/code-generator/parser/parser_resource.go
+++ b/pkg/code-generator/parser/parser_resource.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/iancoleman/strcase"
-	"github.com/pseudomuto/protokit"
+	"github.com/ilackarms/protokit"
 	"github.com/solo-io/solo-kit/pkg/code-generator/model"
 	"github.com/solo-io/solo-kit/pkg/errors"
 	"github.com/solo-io/solo-kit/pkg/utils/log"

--- a/pkg/code-generator/parser/parser_xds.go
+++ b/pkg/code-generator/parser/parser_xds.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
-	"github.com/pseudomuto/protokit"
+	"github.com/ilackarms/protokit"
 	"github.com/solo-io/solo-kit/pkg/code-generator/model"
 	"github.com/solo-io/solo-kit/pkg/errors"
 )


### PR DESCRIPTION
removes a dep file override created in #42 and replaces it with a new hard-fork of `pseudomuto/protokit`