### PR TITLE
simplify defer call

### DIFF
--- a/pkg/code-generator/codegen/templates/event_loop_template.go
+++ b/pkg/code-generator/codegen/templates/event_loop_template.go
@@ -67,7 +67,8 @@ func (el *{{ lower_camel .GoName }}EventLoop) Run(namespaces []string, opts clie
 	go func() {
 		// create a new context for each loop, cancel it before each loop
 		var cancel context.CancelFunc = func() {}
-		defer cancel()
+		// use closure to allow cancel function to be updated as context changes
+		defer func() { cancel() }()
 		for {
 			select {
 			case snapshot, ok := <-watch:

--- a/pkg/code-generator/codegen/templates/event_loop_template.go
+++ b/pkg/code-generator/codegen/templates/event_loop_template.go
@@ -67,7 +67,7 @@ func (el *{{ lower_camel .GoName }}EventLoop) Run(namespaces []string, opts clie
 	go func() {
 		// create a new context for each loop, cancel it before each loop
 		var cancel context.CancelFunc = func() {}
-		defer func() { cancel() }()
+		defer cancel()
 		for {
 			select {
 			case snapshot, ok := <-watch:


### PR DESCRIPTION
Removes redundant function body

This change is valid because from https://golang.org/ref/spec#Defer_statements cancel's arguments (there are no arguments in this case) will be evaluated when defer executes but cancel will not be evaluated until the parent function exits

I tested by:
- making the equivalent change to squash's solo-kit artifacts and running its tests
- making the equivalent changes to gloo's api and setup event loops and running gloo
