### PR TITLE
Register ResourceList type with k8s scheme

### DIFF
--- a/pkg/api/v1/clients/kube/crd/crd.go
+++ b/pkg/api/v1/clients/kube/crd/crd.go
@@ -121,6 +121,7 @@ func (d Crd) Resource(resource string) schema.GroupResource {
 func (d Crd) SchemeBuilder() runtime.SchemeBuilder {
 	return runtime.NewSchemeBuilder(func(scheme *runtime.Scheme) error {
 		scheme.AddKnownTypeWithName(d.SchemeGroupVersion().WithKind(d.KindName), &v1.Resource{})
+		scheme.AddKnownTypeWithName(d.SchemeGroupVersion().WithKind(d.KindName+"List"), &v1.ResourceList{})
 
 		metav1.AddToGroupVersion(scheme, d.SchemeGroupVersion())
 		return nil


### PR DESCRIPTION
When registering a CRD with the kubernetes `scheme` we currently only register the `Register` go type. This PR adds a line to register a `ResourceList` type as well for every CRD. Our regular clients will effectively function exactly in the same way, but it will fix the generated `fake` clientset we use for testing.

More details: Right now [this](https://github.com/kubernetes/apimachinery/blob/849b284f3b756a3fbb5084b09d2718dd41373068/pkg/runtime/serializer/json/json.go#L190) `switch` statement executes the first `case` (we get a `notRegisteredError`). With the change it will execute the `default` clause, but the end result is the same, as the result data of the RESTClient call will be unmarshalled into the same type in both cases.