### PR TITLE
Test template cache fix

### DIFF
--- a/pkg/api/v1/clients/kube/crd/client/clientset/versioned/fake/register.go
+++ b/pkg/api/v1/clients/kube/crd/client/clientset/versioned/fake/register.go
@@ -31,7 +31,7 @@ var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 var parameterCodec = runtime.NewParameterCodec(scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
-	//resourcesv1.AddToScheme,
+//resourcesv1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/pkg/code-generator/codegen/templates/snapshot_emitter_test_template.go
+++ b/pkg/code-generator/codegen/templates/snapshot_emitter_test_template.go
@@ -70,7 +70,9 @@ var _ = Describe("{{ upper_camel .Project.ProjectConfig.Version }}Emitter", func
 		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 		Expect(err).NotTo(HaveOccurred())
 
+{{- if $needs_kube_client }}
 		cache := kuberc.NewKubeCache()
+{{- end}}
 
 {{- if $needs_kube_client }}
 var kube kubernetes.Interface

--- a/test/mocks/v1/testing_event_loop.sk.go
+++ b/test/mocks/v1/testing_event_loop.sk.go
@@ -63,6 +63,7 @@ func (el *testingEventLoop) Run(namespaces []string, opts clients.WatchOpts) (<-
 	go func() {
 		// create a new context for each loop, cancel it before each loop
 		var cancel context.CancelFunc = func() {}
+		// use closure to allow cancel function to be updated as context changes
 		defer func() { cancel() }()
 		for {
 			select {

--- a/test/mocks/v1/testing_snapshot_emitter_test.go
+++ b/test/mocks/v1/testing_snapshot_emitter_test.go
@@ -19,6 +19,9 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	// Needed to run tests in GKE
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
 	// From https://github.com/kubernetes/client-go/blob/53c7adfd0294caa142d961e1f780f74081d5b15f/examples/out-of-cluster-client-configuration/main.go#L31
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -47,14 +50,12 @@ var _ = Describe("V1Emitter", func() {
 		kubeconfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
 		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 		Expect(err).NotTo(HaveOccurred())
-
-		cache := kuberc.NewKubeCache()
 		var kube kubernetes.Interface
 		// MockResource Constructor
 		mockResourceClientFactory := &factory.KubeResourceClientFactory{
 			Crd:         MockResourceCrd,
 			Cfg:         cfg,
-			SharedCache: cache,
+			SharedCache: kuberc.NewKubeCache(),
 		}
 		mockResourceClient, err = NewMockResourceClient(mockResourceClientFactory)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
this fixes a generated test: 
 this change checks ahead-of-time whether any resource does *not* have `HasStatus` set. if not, it creates a kube clientset. if any resource `HasStatus`, it creates a kube cache. if the resource group has both, the test needs both