### PR TITLE
use kubeutils so that the KUBECONFIG env var is respected

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -570,6 +570,14 @@
   version = "v0.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:c4f5e25cc8582ee64fc188ee0b0b2151743c406d23f835d4e3322065207c2f69"
+  name = "github.com/solo-io/go-utils"
+  packages = ["kubeutils"]
+  pruneopts = "UT"
+  revision = "67428b92743fd710ab708665d5fff86e06ff1612"
+
+[[projects]]
   digest = "1:9424f440bba8f7508b69414634aef3b2b3a877e522d8a4624692412805407bb7"
   name = "github.com/spf13/pflag"
   packages = ["."]
@@ -1119,6 +1127,7 @@
     "github.com/onsi/gomega",
     "github.com/pkg/errors",
     "github.com/radovskyb/watcher",
+    "github.com/solo-io/go-utils/kubeutils",
     "go.opencensus.io/exporter/prometheus",
     "go.opencensus.io/stats",
     "go.opencensus.io/stats/view",

--- a/pkg/api/v1/clients/configmap/resource_client_test.go
+++ b/pkg/api/v1/clients/configmap/resource_client_test.go
@@ -2,13 +2,14 @@ package configmap_test
 
 import (
 	"os"
-	"path/filepath"
 	"time"
+
+	"github.com/solo-io/go-utils/kubeutils"
 
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/solo-io/solo-kit/test/mocks/v1"
+	v1 "github.com/solo-io/solo-kit/test/mocks/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -19,7 +20,6 @@ import (
 	"github.com/solo-io/solo-kit/test/tests/generic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	// Needed to run tests in GKE
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -40,8 +40,7 @@ var _ = Describe("Base", func() {
 		namespace = helpers.RandString(8)
 		err := setup.SetupKubeForTest(namespace)
 		Expect(err).NotTo(HaveOccurred())
-		kubeconfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		cfg, err = kubeutils.GetConfig("", "")
 		Expect(err).NotTo(HaveOccurred())
 		kube, err = kubernetes.NewForConfig(cfg)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/api/v1/clients/kube/crd/client/clientset/versioned/clientset_test.go
+++ b/pkg/api/v1/clients/kube/crd/client/clientset/versioned/clientset_test.go
@@ -2,20 +2,20 @@ package versioned_test
 
 import (
 	"os"
-	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd/client/clientset/versioned"
+
+	"github.com/solo-io/go-utils/kubeutils"
 	crdv1 "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd/solo.io/v1"
 	"github.com/solo-io/solo-kit/pkg/utils/log"
 	"github.com/solo-io/solo-kit/test/helpers"
 	mocksv1 "github.com/solo-io/solo-kit/test/mocks/v1"
 	"github.com/solo-io/solo-kit/test/setup"
 	apiexts "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	// Needed to run tests in GKE
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -34,8 +34,7 @@ var _ = Describe("Clientset", func() {
 		namespace = helpers.RandString(8)
 		err := setup.SetupKubeForTest(namespace)
 		Expect(err).NotTo(HaveOccurred())
-		kubeconfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		cfg, err = kubeutils.GetConfig("", "")
 		Expect(err).NotTo(HaveOccurred())
 	})
 	AfterEach(func() {

--- a/pkg/api/v1/clients/kube/resource_client_test.go
+++ b/pkg/api/v1/clients/kube/resource_client_test.go
@@ -2,11 +2,11 @@ package kube_test
 
 import (
 	"os"
-	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/solo-io/go-utils/kubeutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd/client/clientset/versioned"
@@ -17,16 +17,16 @@ import (
 	"github.com/solo-io/solo-kit/pkg/utils/log"
 	"github.com/solo-io/solo-kit/test/helpers"
 	"github.com/solo-io/solo-kit/test/mocks/util"
-	"github.com/solo-io/solo-kit/test/mocks/v1"
+	v1 "github.com/solo-io/solo-kit/test/mocks/v1"
 	"github.com/solo-io/solo-kit/test/setup"
 	"github.com/solo-io/solo-kit/test/tests/generic"
 	apiext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/testing"
-	"k8s.io/client-go/tools/clientcmd"
 
 	// Needed to run tests in GKE
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -75,8 +75,7 @@ var _ = Describe("Test Kube ResourceClient", func() {
 			err := setup.SetupKubeForTest(namespace)
 			Expect(err).NotTo(HaveOccurred())
 
-			kubeconfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-			cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+			cfg, err = kubeutils.GetConfig("", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			clientset, err := versioned.NewForConfig(cfg, v1.MockResourceCrd)

--- a/pkg/api/v1/clients/kubesecret/resource_client_test.go
+++ b/pkg/api/v1/clients/kubesecret/resource_client_test.go
@@ -2,20 +2,19 @@ package kubesecret_test
 
 import (
 	"os"
-	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/solo-io/go-utils/kubeutils"
 	. "github.com/solo-io/solo-kit/pkg/api/v1/clients/kubesecret"
 	"github.com/solo-io/solo-kit/pkg/utils/log"
 	"github.com/solo-io/solo-kit/test/helpers"
-	"github.com/solo-io/solo-kit/test/mocks/v1"
+	v1 "github.com/solo-io/solo-kit/test/mocks/v1"
 	"github.com/solo-io/solo-kit/test/setup"
 	"github.com/solo-io/solo-kit/test/tests/generic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	// Needed to run tests in GKE
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -35,8 +34,7 @@ var _ = Describe("Base", func() {
 		namespace = helpers.RandString(8)
 		err := setup.SetupKubeForTest(namespace)
 		Expect(err).NotTo(HaveOccurred())
-		kubeconfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		cfg, err = kubeutils.GetConfig("", "")
 		Expect(err).NotTo(HaveOccurred())
 		kube, err := kubernetes.NewForConfig(cfg)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/api/v1/clients/kubesecretplain/resource_client_test.go
+++ b/pkg/api/v1/clients/kubesecretplain/resource_client_test.go
@@ -2,16 +2,16 @@ package kubesecretplain_test
 
 import (
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/solo-io/solo-kit/test/mocks/v1"
+	v1 "github.com/solo-io/solo-kit/test/mocks/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/solo-io/go-utils/kubeutils"
 	. "github.com/solo-io/solo-kit/pkg/api/v1/clients/kubesecretplain"
 	"github.com/solo-io/solo-kit/pkg/utils/log"
 	"github.com/solo-io/solo-kit/test/helpers"
@@ -19,7 +19,6 @@ import (
 	"github.com/solo-io/solo-kit/test/tests/generic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	// Needed to run tests in GKE
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -40,8 +39,7 @@ var _ = Describe("Base", func() {
 		namespace = helpers.RandString(8)
 		err := setup.SetupKubeForTest(namespace)
 		Expect(err).NotTo(HaveOccurred())
-		kubeconfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		cfg, err = kubeutils.GetConfig("", "")
 		Expect(err).NotTo(HaveOccurred())
 		kube, err = kubernetes.NewForConfig(cfg)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/code-generator/codegen/templates/snapshot_emitter_test_template.go
+++ b/pkg/code-generator/codegen/templates/snapshot_emitter_test_template.go
@@ -20,7 +20,6 @@ var ResourceGroupEmitterTestTemplate = template.Must(template.New("resource_grou
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"time"
 
 	{{ .Imports }}
@@ -31,9 +30,9 @@ import (
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
 	"github.com/solo-io/solo-kit/test/helpers"
 	"github.com/solo-io/solo-kit/test/setup"
+	"github.com/solo-io/go-utils/kubeutils"
 	kuberc "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	// Needed to run tests in GKE
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -63,11 +62,11 @@ var _ = Describe("{{ upper_camel .Project.ProjectConfig.Version }}Emitter", func
 	BeforeEach(func() {
 		namespace1 = helpers.RandString(8)
 		namespace2 = helpers.RandString(8)
+		cfg, err = kubeutils.GetConfig("", "")
+		Expect(err).NotTo(HaveOccurred())
 		err := setup.SetupKubeForTest(namespace1)
 		Expect(err).NotTo(HaveOccurred())
 		err = setup.SetupKubeForTest(namespace2)
-		kubeconfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 		Expect(err).NotTo(HaveOccurred())
 
 

--- a/pkg/code-generator/codegen/templates/snapshot_emitter_test_template.go
+++ b/pkg/code-generator/codegen/templates/snapshot_emitter_test_template.go
@@ -62,9 +62,9 @@ var _ = Describe("{{ upper_camel .Project.ProjectConfig.Version }}Emitter", func
 	BeforeEach(func() {
 		namespace1 = helpers.RandString(8)
 		namespace2 = helpers.RandString(8)
-		cfg, err = kubeutils.GetConfig("", "")
+		cfg, err := kubeutils.GetConfig("", "")
 		Expect(err).NotTo(HaveOccurred())
-		err := setup.SetupKubeForTest(namespace1)
+		err = setup.SetupKubeForTest(namespace1)
 		Expect(err).NotTo(HaveOccurred())
 		err = setup.SetupKubeForTest(namespace2)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/code-generator/codegen/templates/snapshot_emitter_test_template.go
+++ b/pkg/code-generator/codegen/templates/snapshot_emitter_test_template.go
@@ -62,7 +62,8 @@ var _ = Describe("{{ upper_camel .Project.ProjectConfig.Version }}Emitter", func
 	BeforeEach(func() {
 		namespace1 = helpers.RandString(8)
 		namespace2 = helpers.RandString(8)
-		cfg, err := kubeutils.GetConfig("", "")
+		var err error
+		cfg, err = kubeutils.GetConfig("", "")
 		Expect(err).NotTo(HaveOccurred())
 		err = setup.SetupKubeForTest(namespace1)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/mocks/v1/testing_snapshot_emitter_test.go
+++ b/test/mocks/v1/testing_snapshot_emitter_test.go
@@ -5,11 +5,11 @@ package v1
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/solo-io/go-utils/kubeutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
 	kuberc "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube"
@@ -17,7 +17,6 @@ import (
 	"github.com/solo-io/solo-kit/test/helpers"
 	"github.com/solo-io/solo-kit/test/setup"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	// Needed to run tests in GKE
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -48,8 +47,7 @@ var _ = Describe("V1Emitter", func() {
 		err := setup.SetupKubeForTest(namespace1)
 		Expect(err).NotTo(HaveOccurred())
 		err = setup.SetupKubeForTest(namespace2)
-		kubeconfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		cfg, err = kubeutils.GetConfig("", "")
 		Expect(err).NotTo(HaveOccurred())
 		var kube kubernetes.Interface
 		// MockResource Constructor

--- a/test/tests/typed/typed_rc_tester.go
+++ b/test/tests/typed/typed_rc_tester.go
@@ -3,18 +3,17 @@ package typed
 import (
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"github.com/hashicorp/consul/api"
 	vaultapi "github.com/hashicorp/vault/api"
 	. "github.com/onsi/gomega"
+	"github.com/solo-io/go-utils/kubeutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/memory"
 	"github.com/solo-io/solo-kit/pkg/utils/log"
 	"github.com/solo-io/solo-kit/test/setup"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	// From https://github.com/kubernetes/client-go/blob/53c7adfd0294caa142d961e1f780f74081d5b15f/examples/out-of-cluster-client-configuration/main.go#L31
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
@@ -57,8 +56,7 @@ func (rct *KubeRcTester) Skip() bool {
 func (rct *KubeRcTester) Setup(namespace string) factory.ResourceClientFactory {
 	err := setup.SetupKubeForTest(namespace)
 	Expect(err).NotTo(HaveOccurred())
-	kubeconfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	cfg, err = kubeutils.GetConfig("", "")
 	Expect(err).NotTo(HaveOccurred())
 	return &factory.KubeResourceClientFactory{
 		Crd: rct.Crd,
@@ -190,8 +188,7 @@ func (rct *KubeConfigMapRcTester) Skip() bool {
 func (rct *KubeConfigMapRcTester) Setup(namespace string) factory.ResourceClientFactory {
 	err := setup.SetupKubeForTest(namespace)
 	Expect(err).NotTo(HaveOccurred())
-	kubeconfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	cfg, err = kubeutils.GetConfig("", "")
 	Expect(err).NotTo(HaveOccurred())
 	kube, err := kubernetes.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())
@@ -222,8 +219,7 @@ func (rct *KubeSecretRcTester) Skip() bool {
 func (rct *KubeSecretRcTester) Setup(namespace string) factory.ResourceClientFactory {
 	err := setup.SetupKubeForTest(namespace)
 	Expect(err).NotTo(HaveOccurred())
-	kubeconfigPath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	cfg, err = kubeutils.GetConfig("", "")
 	Expect(err).NotTo(HaveOccurred())
 	kube, err := kubernetes.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
this changes solo-kit not to use an explicit kube config path. this enables using kind for testing.
i've tested that the generated code indeed works with kind (this will be a separate pr to gloo)