### PR TITLE
Exclude whole proto file from docs gen

### DIFF
--- a/pkg/code-generator/docs_gen_test.go
+++ b/pkg/code-generator/docs_gen_test.go
@@ -40,7 +40,7 @@ var _ = Describe("DocsGen", func() {
 		err = ioutil.WriteFile(filepath.Join(tempDir, testProtoName), []byte(buf.String()), 0644)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Generate test proto file for which doc has to be generated
+		// Generate test proto file for which doc has not to be generated
 		buf = &bytes.Buffer{}
 		err = testProtoNoDocsTemplate().Execute(buf, relativePathToTempDir)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/code-generator/docs_gen_test.go
+++ b/pkg/code-generator/docs_gen_test.go
@@ -17,6 +17,7 @@ var _ = Describe("DocsGen", func() {
 
 	const (
 		testProtoName         = "doc_gen_test.proto"
+		testProtoNoDocsName   = "no_doc_gen_test.proto"
 		testProjectConfigName = "solo-kit.json"
 	)
 
@@ -32,11 +33,18 @@ var _ = Describe("DocsGen", func() {
 		Expect(err).NotTo(HaveOccurred())
 		relativePathToTempDir := filepath.Join("github.com/solo-io/solo-kit", filepath.Base(tempDir))
 
-		// Generate test proto file with two messages
+		// Generate test proto file for which doc has to be generated
 		buf := &bytes.Buffer{}
 		err = testProtoTemplate().Execute(buf, relativePathToTempDir)
 		Expect(err).NotTo(HaveOccurred())
 		err = ioutil.WriteFile(filepath.Join(tempDir, testProtoName), []byte(buf.String()), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Generate test proto file for which doc has to be generated
+		buf = &bytes.Buffer{}
+		err = testProtoNoDocsTemplate().Execute(buf, relativePathToTempDir)
+		Expect(err).NotTo(HaveOccurred())
+		err = ioutil.WriteFile(filepath.Join(tempDir, testProtoNoDocsName), []byte(buf.String()), 0644)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Generate project config
@@ -57,10 +65,20 @@ var _ = Describe("DocsGen", func() {
 
 	It("docs for a message are generated based on the value of the skip_docs_gen option", func() {
 
-		// Collect all the generated docs
-		foundExpectedDoc := false
+		// Traverse the generated doc directory tree
+		foundExpectedDoc, foundUnexpectedDoc := false, false
 		err := filepath.Walk(tempDir+"/docs", func(path string, info os.FileInfo, err error) error {
 			if !info.IsDir() {
+
+				// Verify that a doc file has been generated for GenerateDocsForMe
+				if info.Name() == testProtoName+".sk.md" {
+					foundExpectedDoc = true
+				}
+
+				// Verify that no doc file has been generated for DoNotGenerateDocsForMe
+				if info.Name() == testProtoNoDocsName+".sk.md" {
+					foundUnexpectedDoc = true
+				}
 
 				// No file must contain any reference to DoNotGenerateDocsForMe
 				file, err := ioutil.ReadFile(path)
@@ -68,19 +86,13 @@ var _ = Describe("DocsGen", func() {
 				matched, err := regexp.Match("(?i)DoNotGenerateDocsForMe", file)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(matched).To(BeFalse())
-
-				// Verify that GenerateDocsForMe appears in at least one of the generated docs
-				matched, err = regexp.Match("(?i)GenerateDocsForMe", file)
-				Expect(err).NotTo(HaveOccurred())
-				if matched {
-					foundExpectedDoc = true
-				}
-
 			}
 			return nil
 		})
-		Expect(foundExpectedDoc).To(BeTrue())
 		Expect(err).NotTo(HaveOccurred())
+
+		Expect(foundExpectedDoc).To(BeTrue())
+		Expect(foundUnexpectedDoc).To(BeFalse())
 	})
 
 })
@@ -110,6 +122,24 @@ message GenerateDocsForMe {
     string basic_field = 2;
 
 }
+
+`))
+}
+
+func testProtoNoDocsTemplate() *template.Template {
+	return template.Must(template.New("testProtoTemplate").Parse(`
+
+syntax = "proto3";
+
+package testing.solo.io;
+option go_package = "{{.}}";
+
+import "gogoproto/gogo.proto";
+option (gogoproto.equal_all) = true;
+
+import "github.com/solo-io/solo-kit/api/v1/metadata.proto";
+import "github.com/solo-io/solo-kit/api/v1/status.proto";
+import "github.com/solo-io/solo-kit/api/v1/solo-kit.proto";
 
 message DoNotGenerateDocsForMe {
     option (core.solo.io.resource).short_name = "nodocs";

--- a/pkg/code-generator/model/project.go
+++ b/pkg/code-generator/model/project.go
@@ -59,7 +59,7 @@ type Resource struct {
 
 	HasStatus     bool
 	ClusterScoped bool // the resource lives at the cluster level, namespace is ignored
-	SkipDocsGen   bool // if true, no docs will be generated for this resource
+	SkipDocsGen   bool // if true, no docs will be generated for the proto file where this resource is defined
 
 	Fields []*Field
 	Oneofs []*Oneof


### PR DESCRIPTION
Even if a proto file has only messages with `skip_docs_gen` = true, the generator would still create a file for it, just without any meaningful content. With this change the generator will skip any proto file that has a resource that has to be skipped.