### PR TITLE
solve in memory client data race

### DIFF
--- a/pkg/api/v1/clients/memory/resource_client.go
+++ b/pkg/api/v1/clients/memory/resource_client.go
@@ -137,7 +137,10 @@ func (rc *ResourceClient) Read(namespace, name string, opts clients.ReadOpts) (r
 	if !ok {
 		return nil, errors.NewNotExistErr(namespace, name)
 	}
-	return resource, nil
+
+	// avoid data races
+	clone := proto.Clone(resource).(resources.Resource)
+	return clone, nil
 }
 
 func (rc *ResourceClient) Write(resource resources.Resource, opts clients.WriteOpts) (resources.Resource, error) {
@@ -196,7 +199,8 @@ func (rc *ResourceClient) List(namespace string, opts clients.ListOpts) (resourc
 	var resourceList resources.ResourceList
 	for _, resource := range cachedResources {
 		if labels.SelectorFromSet(opts.Selector).Matches(labels.Set(resource.GetMetadata().Labels)) {
-			resourceList = append(resourceList, resource)
+			clone := proto.Clone(resource).(resources.Resource)
+			resourceList = append(resourceList, clone)
 		}
 	}
 

--- a/pkg/api/v1/clients/memory/resource_client_test.go
+++ b/pkg/api/v1/clients/memory/resource_client_test.go
@@ -4,7 +4,10 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	. "github.com/solo-io/solo-kit/pkg/api/v1/clients/memory"
+	core "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	v1 "github.com/solo-io/solo-kit/test/mocks/v1"
 	"github.com/solo-io/solo-kit/test/tests/generic"
 )
@@ -20,5 +23,31 @@ var _ = Describe("Base", func() {
 	})
 	It("CRUDs resources", func() {
 		generic.TestCrudClient("", client, time.Minute)
+	})
+	It("should not return pointer to internal object", func() {
+		obj := &v1.MockResource{
+			Metadata: core.Metadata{
+				Namespace: "ns",
+				Name:      "n",
+			},
+			Data: "test",
+		}
+		client.Write(obj, clients.WriteOpts{})
+		ret, err := client.Read("ns", "n", clients.ReadOpts{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ret).NotTo(BeIdenticalTo(obj))
+
+		ret2, err := client.Read("ns", "n", clients.ReadOpts{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ret).NotTo(BeIdenticalTo(ret2))
+
+		listret, err := client.List("ns", clients.ListOpts{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listret[0]).NotTo(BeIdenticalTo(obj))
+
+		listret2, err := client.List("ns", clients.ListOpts{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listret[0]).NotTo(BeIdenticalTo(listret2[0]))
+
 	})
 })

--- a/pkg/api/v1/reconcile/reconciler_test.go
+++ b/pkg/api/v1/reconcile/reconciler_test.go
@@ -58,6 +58,9 @@ var _ = Describe("Reconciler", func() {
 			resources.UpdateMetadata(mockList[i], func(meta *core.Metadata) {
 				meta.ResourceVersion = ""
 			})
+			resources.UpdateMetadata(desiredMockResources[i], func(meta *core.Metadata) {
+				meta.ResourceVersion = ""
+			})
 			Expect(mockList[i]).To(Equal(desiredMockResources[i]))
 		}
 
@@ -77,6 +80,9 @@ var _ = Describe("Reconciler", func() {
 		Expect(mockList).To(HaveLen(2))
 		for i := range mockList {
 			resources.UpdateMetadata(mockList[i], func(meta *core.Metadata) {
+				meta.ResourceVersion = ""
+			})
+			resources.UpdateMetadata(desiredMockResources[i], func(meta *core.Metadata) {
 				meta.ResourceVersion = ""
 			})
 			Expect(mockList[i]).To(Equal(desiredMockResources[i]))


### PR DESCRIPTION
noticed a failed check in gloo due to a data race in the memory client.
this pr fixes it and adds unit tests.
the fix is to copy values from read and list before returning them, so that the internal values are left unmodified.

while there is no data race in the memory client itself, the contact of solo-kit breaks if the data is not copied, leading to data races in solo-kit users.
