### PR TITLE
add hashable interface

### DIFF
--- a/changelog/v0.3.3/default-transition-function.yaml
+++ b/changelog/v0.3.3/default-transition-function.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Reconcilers now have a default reconcile function, which will use the `Hash()` of resources to prevent re-writing the same resource to storage
+    issueLink: https://github.com/solo-io/solo-kit/issues/96

--- a/changelog/v0.3.3/default-transition-function.yaml
+++ b/changelog/v0.3.3/default-transition-function.yaml
@@ -2,3 +2,6 @@ changelog:
   - type: FIX
     description: Reconcilers now have a default reconcile function, which will use the `Hash()` of resources to prevent re-writing the same resource to storage
     issueLink: https://github.com/solo-io/solo-kit/issues/96
+  - type: NEW_FEATURE
+    description: Solo-Kit exposes an interface which can be used to interact with hashable resources
+    issueLink: https://github.com/solo-io/solo-kit/issues/94

--- a/changelog/v0.3.3/hashable-resource.yaml
+++ b/changelog/v0.3.3/hashable-resource.yaml
@@ -1,4 +1,0 @@
-changelog:
-  - type: NEW_FEATURE
-    description: Solo-Kit exposes an interface which can be used to interact with hashable resources
-    issueLink: https://github.com/solo-io/solo-kit/issues/94

--- a/changelog/v0.3.3/hashable-resource.yaml
+++ b/changelog/v0.3.3/hashable-resource.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Solo-Kit exposes an interface which can be used to interact with hashable resources
+    issueLink: https://github.com/solo-io/solo-kit/issues/94

--- a/pkg/api/v1/resources/resource_interface.go
+++ b/pkg/api/v1/resources/resource_interface.go
@@ -304,6 +304,11 @@ func (list InputResourceList) AsResourceList() ResourceList {
 	return resources
 }
 
+type HashableResource interface {
+	Resource
+	Hash() uint64
+}
+
 func Clone(resource Resource) Resource {
 	return proto.Clone(resource).(Resource)
 }


### PR DESCRIPTION
very tiny pr, it's because i want to be able to get an interface for `Resource` that includes `Hash`  function. basically this is a backwards-compatible way of introducing `Hash()` to the resource interface (as all resources generated since some version of solo-kit have this method)