### PR TITLE
allow overriding crd group name

### DIFF
--- a/changelog/v0.3.4/crd-groupname-override.yaml
+++ b/changelog/v0.3.4/crd-groupname-override.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Solo-Kit now allows overriding the Groupname used for Kubernetes CRDs in the solo-kit.json config
+    issueLink: https://github.com/solo-io/solo-kit/issues/101

--- a/pkg/code-generator/codegen/templates/resource_template.go
+++ b/pkg/code-generator/codegen/templates/resource_template.go
@@ -173,9 +173,14 @@ func (o *{{ .Name }}) DeepCopyObject() runtime.Object {
 	return resources.Clone(o).(*{{ .Name }})
 }
 
-var {{ .Name }}Crd = crd.NewCrd("{{ .Project.ProtoPackage }}",
+{{- $crdGroupName := .Project.ProtoPackage }}
+{{- if ne .Project.ProjectConfig.CrdGroupOverride "" }}
+{{- $crdGroupName = .Project.ProjectConfig.CrdGroupOverride }}
+{{- end}}
+
+var {{ .Name }}Crd = crd.NewCrd("{{ $crdGroupName }}",
 	"{{ lowercase (upper_camel .PluralName) }}",
-	"{{ .Project.ProtoPackage }}",
+	"{{ $crdGroupName }}",
 	"{{ .Project.ProjectConfig.Version }}",
 	"{{ .Name }}",
 	"{{ .ShortName }}",

--- a/pkg/code-generator/model/project.go
+++ b/pkg/code-generator/model/project.go
@@ -25,6 +25,10 @@ type ProjectConfig struct {
 	Version        string                      `json:"version"`
 	DocsDir        string                      `json:"docs_dir"`
 	ResourceGroups map[string][]ResourceConfig `json:"resource_groups"`
+	// if set, this group will override the proto pacakge typically used
+	// as the api group for the crd
+	CrdGroupOverride string `json:"crd_group_override"`
+
 	// set by load
 	ProjectFile string
 	GoPackage   string

--- a/test/mocks/api/v1/solo-kit.json
+++ b/test/mocks/api/v1/solo-kit.json
@@ -3,6 +3,7 @@
   "name": "testing.solo.io",
   "version": "v1",
   "docs_dir": "../doc",
+  "crd_group_override": "crds.testing.solo.io",
   "resource_groups": {
     "testing.solo.io": [
       {

--- a/test/mocks/v1/another_mock_resource.sk.go
+++ b/test/mocks/v1/another_mock_resource.sk.go
@@ -157,9 +157,9 @@ func (o *AnotherMockResource) DeepCopyObject() runtime.Object {
 	return resources.Clone(o).(*AnotherMockResource)
 }
 
-var AnotherMockResourceCrd = crd.NewCrd("testing.solo.io",
+var AnotherMockResourceCrd = crd.NewCrd("crds.testing.solo.io",
 	"anothermockresources",
-	"testing.solo.io",
+	"crds.testing.solo.io",
 	"v1",
 	"AnotherMockResource",
 	"amr",

--- a/test/mocks/v1/cluster_resource.sk.go
+++ b/test/mocks/v1/cluster_resource.sk.go
@@ -157,9 +157,9 @@ func (o *ClusterResource) DeepCopyObject() runtime.Object {
 	return resources.Clone(o).(*ClusterResource)
 }
 
-var ClusterResourceCrd = crd.NewCrd("testing.solo.io",
+var ClusterResourceCrd = crd.NewCrd("crds.testing.solo.io",
 	"clusterresources",
-	"testing.solo.io",
+	"crds.testing.solo.io",
 	"v1",
 	"ClusterResource",
 	"clr",

--- a/test/mocks/v1/fake_resource.sk.go
+++ b/test/mocks/v1/fake_resource.sk.go
@@ -145,9 +145,9 @@ func (o *FakeResource) DeepCopyObject() runtime.Object {
 	return resources.Clone(o).(*FakeResource)
 }
 
-var FakeResourceCrd = crd.NewCrd("testing.solo.io",
+var FakeResourceCrd = crd.NewCrd("crds.testing.solo.io",
 	"fakes",
-	"testing.solo.io",
+	"crds.testing.solo.io",
 	"v1",
 	"FakeResource",
 	"fk",

--- a/test/mocks/v1/mock_resource.sk.go
+++ b/test/mocks/v1/mock_resource.sk.go
@@ -158,9 +158,9 @@ func (o *MockResource) DeepCopyObject() runtime.Object {
 	return resources.Clone(o).(*MockResource)
 }
 
-var MockResourceCrd = crd.NewCrd("testing.solo.io",
+var MockResourceCrd = crd.NewCrd("crds.testing.solo.io",
 	"mocks",
-	"testing.solo.io",
+	"crds.testing.solo.io",
 	"v1",
 	"MockResource",
 	"mk",

--- a/test/mocks/v1/mock_resources.pb.go
+++ b/test/mocks/v1/mock_resources.pb.go
@@ -11,14 +11,13 @@ import (
 	bytes "bytes"
 	context "context"
 	fmt "fmt"
-	math "math"
-
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	core "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/test/mocks/v1/more_mock_resources.pb.go
+++ b/test/mocks/v1/more_mock_resources.pb.go
@@ -6,11 +6,10 @@ package v1
 import (
 	bytes "bytes"
 	fmt "fmt"
-	math "math"
-
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	core "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
currently crd group name is set from the proto package

for some reason, Istio decided to have different proto packages and crd group names. this allows us to set an override so the apigroups of our generated crds match theirs (in supergloo)