### PR TITLE
Fix warning plainsecret

### DIFF
--- a/changelog/v0.3.7/update_control_plane.yaml
+++ b/changelog/v0.3.7/update_control_plane.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix warning on metadata field in plain secret client

--- a/pkg/api/v1/clients/kubesecret/resource_client.go
+++ b/pkg/api/v1/clients/kubesecret/resource_client.go
@@ -115,6 +115,11 @@ func (p *plainSecret) ToKubeSecret(ctx context.Context, rc *ResourceClient, reso
 	}
 	kubeSecretData := make(map[string][]byte)
 	for k, v := range resourceMap {
+		// metadata comes from ToKubeMeta
+		// status not supported
+		if k == "metadata" {
+			continue
+		}
 		switch val := v.(type) {
 		case string:
 			kubeSecretData[k] = []byte(val)


### PR DESCRIPTION
fixes an annoying/meaningless warning unnoticed until now because we never had a CLI using plain secrets.