### PR TITLE
Continue setting "version" on CRDs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -562,7 +562,7 @@
   version = "v0.1"
 
 [[projects]]
-  digest = "1:bba31bb46164a88a6f10ac118286db76f4a8c894a74cc87d00162c32149a1b1f"
+  digest = "1:5dd2d00c9726046d285699a353e6cad45dc606fa77a2f1f378c777bb047d0af4"
   name = "github.com/solo-io/go-utils"
   packages = [
     "clicore/constants",
@@ -577,6 +577,7 @@
     "testutils",
     "testutils/clusterlock",
     "testutils/kube",
+    "versionutils/kubeapi",
   ]
   pruneopts = "UT"
   revision = "8eada3e906dc4de9810cf93455a476e7121fa5f4"
@@ -1268,6 +1269,7 @@
     "github.com/solo-io/go-utils/testutils",
     "github.com/solo-io/go-utils/testutils/clusterlock",
     "github.com/solo-io/go-utils/testutils/kube",
+    "github.com/solo-io/go-utils/versionutils/kubeapi",
     "go.opencensus.io/stats",
     "go.opencensus.io/stats/view",
     "go.opencensus.io/tag",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -562,7 +562,7 @@
   version = "v0.1"
 
 [[projects]]
-  digest = "1:46b816b3c115aa07ca2537c0870e9e1f35c3b6920563b665dcbabaa510d1eb6c"
+  digest = "1:bba31bb46164a88a6f10ac118286db76f4a8c894a74cc87d00162c32149a1b1f"
   name = "github.com/solo-io/go-utils"
   packages = [
     "clicore/constants",
@@ -579,8 +579,8 @@
     "testutils/kube",
   ]
   pruneopts = "UT"
-  revision = "1c2dd400703ec1a7340609a6f5c00653ecf3d5c7"
-  version = "v0.9.1"
+  revision = "8eada3e906dc4de9810cf93455a476e7121fa5f4"
+  version = "v0.9.9"
 
 [[projects]]
   digest = "1:9424f440bba8f7508b69414634aef3b2b3a877e522d8a4624692412805407bb7"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
 
 [[constraint]]
   name = "github.com/solo-io/go-utils"
-  version = "0.9.1"
+  version = "0.9.9"
 
 [[constraint]]
   version = ">=0.8.0"

--- a/changelog/v0.10.3/set-version-crd.yaml
+++ b/changelog/v0.10.3/set-version-crd.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Set version field when registering CRDs.
+    issueLink: https://github.com/solo-io/solo-kit/issues/220

--- a/pkg/api/v1/clients/kube/crd/crd.go
+++ b/pkg/api/v1/clients/kube/crd/crd.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"sync"
 
-	"github.com/solo-io/go-utils/versionutils/kubeapi"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd/client/clientset/versioned/scheme"
 	v1 "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd/solo.io/v1"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
@@ -32,31 +31,6 @@ type Version struct {
 	Type    runtime.Object
 }
 
-type VersionList []Version
-
-func (list VersionList) GetLatestVersion() Version {
-	var latest Version
-	var latestParsed kubeapi.Version
-	for _, v := range list {
-		parsed, err := kubeapi.ParseVersion(v.Version)
-		if err != nil {
-			continue
-		}
-		if latestParsed == nil {
-			latestParsed = parsed
-		}
-		if parsed.GreaterThan(latestParsed) {
-			latest = v
-			latestParsed = parsed
-		}
-	}
-	// If none of the versions are any good, return the first one.
-	if latest.Version == "" && len(list) > 0 {
-		return list[0]
-	}
-	return latest
-}
-
 type Crd struct {
 	CrdMeta
 	Version Version
@@ -64,7 +38,7 @@ type Crd struct {
 
 type MultiVersionCrd struct {
 	CrdMeta
-	Versions VersionList
+	Versions []Version
 }
 
 func NewCrd(

--- a/pkg/api/v1/clients/kube/crd/crd.go
+++ b/pkg/api/v1/clients/kube/crd/crd.go
@@ -42,6 +42,9 @@ func (list VersionList) GetLatestVersion() Version {
 		if err != nil {
 			continue
 		}
+		if latestParsed == nil {
+			latestParsed = parsed
+		}
 		if parsed.GreaterThan(latestParsed) {
 			latest = v
 			latestParsed = parsed

--- a/pkg/api/v1/clients/kube/crd/registry.go
+++ b/pkg/api/v1/clients/kube/crd/registry.go
@@ -146,6 +146,7 @@ func (r crdRegistry) getKubeCrd(crd MultiVersionCrd, gvk schema.GroupVersionKind
 				ShortNames: []string{crd.ShortName},
 			},
 			Versions: versions,
+			Version:  crd.Versions.GetLatestVersion().Version,
 		},
 	}, nil
 }

--- a/pkg/api/v1/clients/kube/crd/registry.go
+++ b/pkg/api/v1/clients/kube/crd/registry.go
@@ -139,7 +139,7 @@ func (r crdRegistry) getKubeCrd(crd MultiVersionCrd, gvk schema.GroupVersionKind
 	}
 
 	// Kubernetes expects Version to match the name of the first element specified in the Versions list.
-	// We specify the latest version there, so we must also sort the list of versions from latest to oldest.
+	// Sort so the first version in the list will also be the latest.
 	sort.Slice(versions, func(i, j int) bool {
 		parsedi, err := kubeapi.ParseVersion(versions[i].Name)
 		if err != nil {
@@ -163,7 +163,7 @@ func (r crdRegistry) getKubeCrd(crd MultiVersionCrd, gvk schema.GroupVersionKind
 				ShortNames: []string{crd.ShortName},
 			},
 			Versions: versions,
-			Version:  crd.Versions.GetLatestVersion().Version,
+			Version:  versions[0].Name,
 		},
 	}, nil
 }


### PR DESCRIPTION
"Version" is deprecated on newer versions of Kubernetes, but it's required on 1.10.
BOT NOTES: 
resolves https://github.com/solo-io/solo-kit/issues/220