### PR TITLE
Return empty list instead of error on vault client when no resources …

### DIFF
--- a/changelog/v0.10.6/empty-list-instead-of-err.yaml
+++ b/changelog/v0.10.6/empty-list-instead-of-err.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Return empty list instead of error on vault client when no resources exist
+    issueLink: https://github.com/solo-io/solo-kit/issues/228

--- a/pkg/api/v1/clients/vault/resource_client.go
+++ b/pkg/api/v1/clients/vault/resource_client.go
@@ -239,7 +239,7 @@ func (rc *ResourceClient) listKeys(directory string) ([]string, error) {
 		return nil, errors.Wrapf(err, "listing directory %v", directory)
 	}
 	if keyList == nil {
-		return nil, errors.Errorf("directory %v not found", directory)
+		return []string{}, nil
 	}
 	val, ok := keyList.Data["keys"]
 	if !ok {

--- a/pkg/api/v1/clients/vault/resource_client_test.go
+++ b/pkg/api/v1/clients/vault/resource_client_test.go
@@ -26,6 +26,7 @@ var _ = Describe("Base", func() {
 		cfg := api.DefaultConfig()
 		cfg.Address = fmt.Sprintf("http://127.0.0.1:%v", vaultInstance.Port)
 		c, err := api.NewClient(cfg)
+		Expect(err).NotTo(HaveOccurred())
 		c.SetToken(vaultInstance.Token())
 		Expect(err).NotTo(HaveOccurred())
 		vault = c

--- a/test/tests/generic/test_crud_client.go
+++ b/test/tests/generic/test_crud_client.go
@@ -33,6 +33,11 @@ func TestCrudClient(namespace1, namespace2 string, client ResourceClient, opts c
 	err := client.Register()
 	Expect(err).NotTo(HaveOccurred())
 
+	// list with no resources should return empty list, not err
+	list, err := client.List("", clients.ListOpts{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(list).To(BeEmpty())
+
 	r1, err := client.Write(input, clients.WriteOpts{})
 	Expect(err).NotTo(HaveOccurred())
 	postWrite(callbacks, r1)
@@ -91,7 +96,7 @@ func TestCrudClient(namespace1, namespace2 string, client ResourceClient, opts c
 	Expect(err).NotTo(HaveOccurred())
 
 	// with labels
-	list, err := client.List("", clients.ListOpts{
+	list, err = client.List("", clients.ListOpts{
 		Selector: labels,
 	})
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
…exist
BOT NOTES: 
resolves https://github.com/solo-io/solo-kit/issues/228