### PR TITLE
Reduce log level in reporters

### DIFF
--- a/changelog/v0.11.1/reduce-reporter-log-level.yaml
+++ b/changelog/v0.11.1/reduce-reporter-log-level.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: NON_USER_FACING
+  description: Reduce log level in reporters.

--- a/pkg/api/v1/reporter/reporter.go
+++ b/pkg/api/v1/reporter/reporter.go
@@ -115,7 +115,7 @@ func (r *reporter) WriteReports(ctx context.Context, resourceErrs ResourceErrors
 			meta.ResourceVersion = res.GetMetadata().ResourceVersion
 		})
 
-		logger.Infof("wrote report %v : %v", resourceToWrite.GetMetadata().Ref(), status)
+		logger.Debugf("wrote report %v : %v", resourceToWrite.GetMetadata().Ref(), status)
 	}
 	return merr.ErrorOrNil()
 }

--- a/pkg/api/v2/reporter/reporter.go
+++ b/pkg/api/v2/reporter/reporter.go
@@ -171,7 +171,7 @@ func (r *reporter) WriteReports(ctx context.Context, resourceErrs ResourceReport
 			meta.ResourceVersion = res.GetMetadata().ResourceVersion
 		})
 
-		logger.Infof("wrote report %v : %v", resourceToWrite.GetMetadata().Ref(), status)
+		logger.Debugf("wrote report %v : %v", resourceToWrite.GetMetadata().Ref(), status)
 	}
 	return merr.ErrorOrNil()
 }


### PR DESCRIPTION
Currently the reporters log this message after writing the status on a resource:

```go
logger.Infof("wrote report %v : %v", resourceToWrite.GetMetadata().Ref(), status)
```

This leads to a lot of noise in the logs and imho does not provide a lot of value:

![image](https://user-images.githubusercontent.com/16148461/67100822-672a8280-f18e-11e9-9df3-04119bfc8652.png)

I propose reducing the level of that log message to `debug` to make the logs leaner.