### PR TITLE
Add a mapping for google/protobuf/empty.proto

### DIFF
--- a/changelog/v0.11.7/protoc-mapping-empty.yaml
+++ b/changelog/v0.11.7/protoc-mapping-empty.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: NON_USER_FACING
+  description: Add a mapping for `google/protobuf/empty.proto` to the `protoc` arguments.

--- a/pkg/code-generator/cmd/main.go
+++ b/pkg/code-generator/cmd/main.go
@@ -472,6 +472,7 @@ var defaultGogoArgs = []string{
 	"Mgoogle/protobuf/descriptor.proto=github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
 	"Mgoogle/protobuf/any.proto=github.com/gogo/protobuf/types",
 	"Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types",
+	"Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types",
 	"Mgoogle/protobuf/struct.proto=github.com/gogo/protobuf/types",
 	"Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types",
 	"Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types",


### PR DESCRIPTION
Add a mapping for `google/protobuf/empty.proto` to the `protoc` arguments.