### PR TITLE
Set cluster on kube resources

### DIFF
--- a/changelog/v0.11.9/return-cluster-clients-from-factory.yaml
+++ b/changelog/v0.11.9/return-cluster-clients-from-factory.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Return cluster clients from all cluster client factories.

--- a/pkg/api/external/kubernetes/configmap/configmap_resource_client_factory.go
+++ b/pkg/api/external/kubernetes/configmap/configmap_resource_client_factory.go
@@ -5,6 +5,7 @@ import (
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/configmap"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/cache"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/multicluster/factory"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients/wrapper"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 	"github.com/solo-io/solo-kit/pkg/errors"
 	"github.com/solo-io/solo-kit/pkg/multicluster/clustercache"
@@ -37,5 +38,9 @@ func (g *configmapResourceClientFactory) GetClient(cluster string, restConfig *r
 	if !ok {
 		return nil, errors.Errorf("expected KubeCoreCache, got %T", kubeCache)
 	}
-	return configmap.NewResourceClient(kube, g.resourceType, typedCache, true)
+	client, err := configmap.NewResourceClient(kube, g.resourceType, typedCache, true)
+	if err != nil {
+		return nil, err
+	}
+	return wrapper.NewClusterResourceClient(client, cluster), nil
 }

--- a/pkg/api/external/kubernetes/customresourcedefinition/crd_resource_client_factory.go
+++ b/pkg/api/external/kubernetes/customresourcedefinition/crd_resource_client_factory.go
@@ -3,6 +3,7 @@ package customresourcedefinition
 import (
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/multicluster/factory"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients/wrapper"
 	"github.com/solo-io/solo-kit/pkg/errors"
 	"github.com/solo-io/solo-kit/pkg/multicluster/clustercache"
 	apiexts "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -29,5 +30,5 @@ func (g *crdResourceClientFactory) GetClient(cluster string, restConfig *rest.Co
 	if !ok {
 		return nil, errors.Errorf("expected KubeCustomResourceDefinitionCache, got %T", kubeCache)
 	}
-	return newResourceClient(kube, typedCache), nil
+	return wrapper.NewClusterResourceClient(newResourceClient(kube, typedCache), cluster), nil
 }

--- a/pkg/api/external/kubernetes/deployment/deployment_resource_client_factory.go
+++ b/pkg/api/external/kubernetes/deployment/deployment_resource_client_factory.go
@@ -4,6 +4,7 @@ import (
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/cache"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/multicluster/factory"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients/wrapper"
 	"github.com/solo-io/solo-kit/pkg/errors"
 	"github.com/solo-io/solo-kit/pkg/multicluster/clustercache"
 	"k8s.io/client-go/kubernetes"
@@ -30,5 +31,5 @@ func (g *deploymentResourceClientFactory) GetClient(cluster string, restConfig *
 	if !ok {
 		return nil, errors.Errorf("expected KubeDeploymentCache, got %T", kubeCache)
 	}
-	return newResourceClient(kube, typedCache), nil
+	return wrapper.NewClusterResourceClient(newResourceClient(kube, typedCache), cluster), nil
 }

--- a/pkg/api/external/kubernetes/namespace/namespace_resource_client_factory.go
+++ b/pkg/api/external/kubernetes/namespace/namespace_resource_client_factory.go
@@ -5,6 +5,7 @@ import (
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/cache"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/multicluster/factory"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients/wrapper"
 	"github.com/solo-io/solo-kit/pkg/multicluster/clustercache"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -30,5 +31,5 @@ func (g *namespaceResourceClientFactory) GetClient(cluster string, restConfig *r
 	if !ok {
 		return nil, errors.Errorf("expected KubeCoreCache, got %T", kubeCache)
 	}
-	return newResourceClient(kube, typedCache), nil
+	return wrapper.NewClusterResourceClient(newResourceClient(kube, typedCache), cluster), nil
 }

--- a/pkg/api/external/kubernetes/pod/pod_resource_client_factory.go
+++ b/pkg/api/external/kubernetes/pod/pod_resource_client_factory.go
@@ -4,6 +4,7 @@ import (
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/cache"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/multicluster/factory"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients/wrapper"
 	"github.com/solo-io/solo-kit/pkg/errors"
 	"github.com/solo-io/solo-kit/pkg/multicluster/clustercache"
 	"k8s.io/client-go/kubernetes"
@@ -12,7 +13,6 @@ import (
 
 type podResourceClientFactory struct {
 	cacheGetter clustercache.CacheGetter
-	test        clustercache.ClusterCache
 }
 
 var _ factory.ClusterClientFactory = &podResourceClientFactory{}
@@ -31,5 +31,5 @@ func (g *podResourceClientFactory) GetClient(cluster string, restConfig *rest.Co
 	if !ok {
 		return nil, errors.Errorf("expected KubeCoreCache, got %T", kubeCache)
 	}
-	return newResourceClient(kube, typedCache), nil
+	return wrapper.NewClusterResourceClient(newResourceClient(kube, typedCache), cluster), nil
 }

--- a/pkg/api/external/kubernetes/service/service_resource_client_factory.go
+++ b/pkg/api/external/kubernetes/service/service_resource_client_factory.go
@@ -4,6 +4,7 @@ import (
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/cache"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/multicluster/factory"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients/wrapper"
 	"github.com/solo-io/solo-kit/pkg/errors"
 	"github.com/solo-io/solo-kit/pkg/multicluster/clustercache"
 	"k8s.io/client-go/kubernetes"
@@ -30,5 +31,5 @@ func (g *serviceResourceClientFactory) GetClient(cluster string, restConfig *res
 	if !ok {
 		return nil, errors.Errorf("expected KubeCoreCache, got %T", kubeCache)
 	}
-	return newResourceClient(kube, typedCache), nil
+	return wrapper.NewClusterResourceClient(newResourceClient(kube, typedCache), cluster), nil
 }

--- a/pkg/api/v1/clients/wrapper/common_wrappers.go
+++ b/pkg/api/v1/clients/wrapper/common_wrappers.go
@@ -16,3 +16,11 @@ func NewClusterClient(base clients.ResourceClient, cluster string) *Client {
 		},
 	}
 }
+
+// Convenience function for wrapping clients only if they point to remote clusters.
+func NewClusterResourceClient(base clients.ResourceClient, cluster string) clients.ResourceClient {
+	if cluster == "" {
+		return base
+	}
+	return NewClusterClient(base, cluster)
+}


### PR DESCRIPTION
Wrap clients returned from kube client factories so we have cluster context before they're invoked in callbacks and accessible in the client set.