### PR TITLE
clean up external envoy API docs

### DIFF
--- a/api/external/envoy/api/v2/core/base.proto
+++ b/api/external/envoy/api/v2/core/base.proto
@@ -23,8 +23,8 @@ option (extproto.hash_all) = true;
 
 // [#protodoc-title: Common types]
 
-// Envoy supports :ref:`upstream priority routing
-// <arch_overview_http_routing_priority>` both at the route and the virtual
+// Envoy supports `upstream priority routing
+// (arch_overview_http_routing_priority)` both at the route and the virtual
 // cluster level. The current priority implementation uses different connection
 // pool and circuit breaking settings for each priority level. This means that
 // even for HTTP/2 requests, two physical connections will be used to an
@@ -63,12 +63,12 @@ enum TrafficDirection {
 
 // Identifies location of where either Envoy runs or where upstream hosts run.
 message Locality {
-  // Region this :ref:`zone <envoy_api_field_core.Locality.zone>` belongs to.
+  // Region this `zone (envoy_api_field_core.Locality.zone)` belongs to.
   string region = 1;
 
   // Defines the local service zone where Envoy is running. Though optional, it
   // should be set if discovery service routing is used and the discovery
-  // service exposes :ref:`zone data <envoy_api_field_endpoint.LocalityLbEndpoints.locality>`,
+  // service exposes `zone data (envoy_api_field_endpoint.LocalityLbEndpoints.locality)`,
   // either in this message or via :option:`--service-zone`. The meaning of zone
   // is context dependent, e.g. `Availability Zone (AZ)
   // <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html>`_
@@ -88,22 +88,22 @@ message Locality {
 message Node {
   // An opaque node identifier for the Envoy node. This also provides the local
   // service node name. It should be set if any of the following features are
-  // used: :ref:`statsd <arch_overview_statistics>`, :ref:`CDS
-  // <config_cluster_manager_cds>`, and :ref:`HTTP tracing
-  // <arch_overview_tracing>`, either in this message or via
+  // used: `statsd (arch_overview_statistics)`, `CDS
+  // (config_cluster_manager_cds)`, and `HTTP tracing
+  // (arch_overview_tracing)`, either in this message or via
   // :option:`--service-node`.
   string id = 1;
 
   // Defines the local service cluster name where Envoy is running. Though
   // optional, it should be set if any of the following features are used:
-  // :ref:`statsd <arch_overview_statistics>`, :ref:`health check cluster
-  // verification <envoy_api_field_core.HealthCheck.HttpHealthCheck.service_name>`,
-  // :ref:`runtime override directory <envoy_api_msg_config.bootstrap.v2.Runtime>`,
-  // :ref:`user agent addition
-  // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.add_user_agent>`,
-  // :ref:`HTTP global rate limiting <config_http_filters_rate_limit>`,
-  // :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
-  // <arch_overview_tracing>`, either in this message or via
+  // `statsd (arch_overview_statistics)`, `health check cluster
+  // verification (envoy_api_field_core.HealthCheck.HttpHealthCheck.service_name)`,
+  // `runtime override directory (envoy_api_msg_config.bootstrap.v2.Runtime)`,
+  // `user agent addition
+  // (envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.add_user_agent)`,
+  // `HTTP global rate limiting (config_http_filters_rate_limit)`,
+  // `CDS (config_cluster_manager_cds)`, and `HTTP tracing
+  // (arch_overview_tracing)`, either in this message or via
   // :option:`--service-cluster`.
   string cluster = 2;
 
@@ -174,8 +174,8 @@ message HeaderValue {
 
   // Header value.
   //
-  // The same :ref:`format specifier <config_access_log_format>` as used for
-  // :ref:`HTTP access logging <config_access_log>` applies here, however
+  // The same `format specifier (config_access_log_format)` as used for
+  // `HTTP access logging (config_access_log)` applies here, however
   // unknown header values are replaced with the empty string instead of `-`.
   string value = 2 [(validate.rules).string = {max_bytes: 16384}];
 }
@@ -233,8 +233,8 @@ message AsyncDataSource {
   }
 }
 
-// Configuration for transport socket in :ref:`listeners <config_listeners>` and
-// :ref:`clusters <envoy_api_msg_Cluster>`. If the configuration is
+// Configuration for transport socket in `listeners (config_listeners)` and
+// `clusters (envoy_api_msg_Cluster)`. If the configuration is
 // empty, a default transport socket implementation and configuration will be
 // chosen based on the platform and existence of tls_context.
 message TransportSocket {

--- a/api/external/envoy/api/v2/discovery.proto
+++ b/api/external/envoy/api/v2/discovery.proto
@@ -58,7 +58,7 @@ message DiscoveryRequest {
   // delta, where it is populated only for new explicit ACKs).
   string response_nonce = 5;
 
-  // This is populated when the previous :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`
+  // This is populated when the previous `DiscoveryResponse (envoy_api_msg_DiscoveryResponse)`
   // failed to update configuration. The *message* field in *error_details* provides the Envoy
   // internal exception related to the failure. It is only intended for consumption during manual
   // debugging, the string provided is not guaranteed to be stable across Envoy versions.
@@ -189,7 +189,7 @@ message DeltaDiscoveryRequest {
   // Otherwise (unlike in DiscoveryRequest) response_nonce must be omitted.
   string response_nonce = 6;
 
-  // This is populated when the previous :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`
+  // This is populated when the previous `DiscoveryResponse (envoy_api_msg_DiscoveryResponse)`
   // failed to update configuration. The *message* field in *error_details*
   // provides the Envoy internal exception related to the failure.
   google.rpc.Status error_detail = 7;

--- a/changelog/v0.13.2/cleanup-envoy-api-comments.yaml
+++ b/changelog/v0.13.2/cleanup-envoy-api-comments.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/2291

--- a/ci/check-code-gen.sh
+++ b/ci/check-code-gen.sh
@@ -22,7 +22,7 @@ if [[ $? -ne 0 ]]; then
 fi
 if [[ $(git status --porcelain | wc -l) -ne 0 ]]; then
   echo "Generating code produced a non-empty diff."
-  echo "Try running 'dep ensure && make install-codegen-deps generated-code -B' then re-pushing."
+  echo "Try running 'make update-deps generated-code -B' then re-pushing."
   git status --porcelain
   git diff | cat
   exit 1;

--- a/pkg/api/external/envoy/api/v2/core/base.pb.go
+++ b/pkg/api/external/envoy/api/v2/core/base.pb.go
@@ -27,8 +27,8 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// Envoy supports :ref:`upstream priority routing
-// <arch_overview_http_routing_priority>` both at the route and the virtual
+// Envoy supports `upstream priority routing
+// (arch_overview_http_routing_priority)` both at the route and the virtual
 // cluster level. The current priority implementation uses different connection
 // pool and circuit breaking settings for each priority level. This means that
 // even for HTTP/2 requests, two physical connections will be used to an
@@ -174,11 +174,11 @@ func (SocketOption_SocketState) EnumDescriptor() ([]byte, []int) {
 
 // Identifies location of where either Envoy runs or where upstream hosts run.
 type Locality struct {
-	// Region this :ref:`zone <envoy_api_field_core.Locality.zone>` belongs to.
+	// Region this `zone (envoy_api_field_core.Locality.zone)` belongs to.
 	Region string `protobuf:"bytes,1,opt,name=region,proto3" json:"region,omitempty"`
 	// Defines the local service zone where Envoy is running. Though optional, it
 	// should be set if discovery service routing is used and the discovery
-	// service exposes :ref:`zone data <envoy_api_field_endpoint.LocalityLbEndpoints.locality>`,
+	// service exposes `zone data (envoy_api_field_endpoint.LocalityLbEndpoints.locality)`,
 	// either in this message or via :option:`--service-zone`. The meaning of zone
 	// is context dependent, e.g. `Availability Zone (AZ)
 	// <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html>`_
@@ -245,21 +245,21 @@ func (m *Locality) GetSubZone() string {
 type Node struct {
 	// An opaque node identifier for the Envoy node. This also provides the local
 	// service node name. It should be set if any of the following features are
-	// used: :ref:`statsd <arch_overview_statistics>`, :ref:`CDS
-	// <config_cluster_manager_cds>`, and :ref:`HTTP tracing
-	// <arch_overview_tracing>`, either in this message or via
+	// used: `statsd (arch_overview_statistics)`, `CDS
+	// (config_cluster_manager_cds)`, and `HTTP tracing
+	// (arch_overview_tracing)`, either in this message or via
 	// :option:`--service-node`.
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Defines the local service cluster name where Envoy is running. Though
 	// optional, it should be set if any of the following features are used:
-	// :ref:`statsd <arch_overview_statistics>`, :ref:`health check cluster
-	// verification <envoy_api_field_core.HealthCheck.HttpHealthCheck.service_name>`,
-	// :ref:`runtime override directory <envoy_api_msg_config.bootstrap.v2.Runtime>`,
-	// :ref:`user agent addition
-	// <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.add_user_agent>`,
-	// :ref:`HTTP global rate limiting <config_http_filters_rate_limit>`,
-	// :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
-	// <arch_overview_tracing>`, either in this message or via
+	// `statsd (arch_overview_statistics)`, `health check cluster
+	// verification (envoy_api_field_core.HealthCheck.HttpHealthCheck.service_name)`,
+	// `runtime override directory (envoy_api_msg_config.bootstrap.v2.Runtime)`,
+	// `user agent addition
+	// (envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.add_user_agent)`,
+	// `HTTP global rate limiting (config_http_filters_rate_limit)`,
+	// `CDS (config_cluster_manager_cds)`, and `HTTP tracing
+	// (arch_overview_tracing)`, either in this message or via
 	// :option:`--service-cluster`.
 	Cluster string `protobuf:"bytes,2,opt,name=cluster,proto3" json:"cluster,omitempty"`
 	// Opaque metadata extending the node identifier. Envoy will pass this
@@ -502,8 +502,8 @@ type HeaderValue struct {
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// Header value.
 	//
-	// The same :ref:`format specifier <config_access_log_format>` as used for
-	// :ref:`HTTP access logging <config_access_log>` applies here, however
+	// The same `format specifier (config_access_log_format)` as used for
+	// `HTTP access logging (config_access_log)` applies here, however
 	// unknown header values are replaced with the empty string instead of `-`.
 	Value                string   `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -858,8 +858,8 @@ func (*AsyncDataSource) XXX_OneofWrappers() []interface{} {
 	}
 }
 
-// Configuration for transport socket in :ref:`listeners <config_listeners>` and
-// :ref:`clusters <envoy_api_msg_Cluster>`. If the configuration is
+// Configuration for transport socket in `listeners (config_listeners)` and
+// `clusters (envoy_api_msg_Cluster)`. If the configuration is
 // empty, a default transport socket implementation and configuration will be
 // chosen based on the platform and existence of tls_context.
 type TransportSocket struct {

--- a/pkg/api/external/envoy/api/v2/discovery.pb.go
+++ b/pkg/api/external/envoy/api/v2/discovery.pb.go
@@ -58,7 +58,7 @@ type DiscoveryRequest struct {
 	// or 2) the client has not yet accepted an update in this xDS stream (unlike
 	// delta, where it is populated only for new explicit ACKs).
 	ResponseNonce string `protobuf:"bytes,5,opt,name=response_nonce,json=responseNonce,proto3" json:"response_nonce,omitempty"`
-	// This is populated when the previous :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`
+	// This is populated when the previous `DiscoveryResponse (envoy_api_msg_DiscoveryResponse)`
 	// failed to update configuration. The *message* field in *error_details* provides the Envoy
 	// internal exception related to the failure. It is only intended for consumption during manual
 	// debugging, the string provided is not guaranteed to be stable across Envoy versions.
@@ -316,7 +316,7 @@ type DeltaDiscoveryRequest struct {
 	// nonce in the DeltaDiscoveryResponse.
 	// Otherwise (unlike in DiscoveryRequest) response_nonce must be omitted.
 	ResponseNonce string `protobuf:"bytes,6,opt,name=response_nonce,json=responseNonce,proto3" json:"response_nonce,omitempty"`
-	// This is populated when the previous :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`
+	// This is populated when the previous `DiscoveryResponse (envoy_api_msg_DiscoveryResponse)`
 	// failed to update configuration. The *message* field in *error_details*
 	// provides the Envoy internal exception related to the failure.
 	ErrorDetail          *rpc.Status `protobuf:"bytes,7,opt,name=error_detail,json=errorDetail,proto3" json:"error_detail,omitempty"`


### PR DESCRIPTION
When we render our external API docs from external envoy protos, the comments get rendered incorrectly. Envoy uses some formatting in their comments that we don't use, (e.g. :ref:``).
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2291