### PR TITLE
Dont use pointer memory leak

### DIFF
--- a/changelog/v0.13.4/fix-memory-leak-workqueue.yaml
+++ b/changelog/v0.13.4/fix-memory-leak-workqueue.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    description: >
+      Fix memory leak in active (event-heavy) kubernetes environments which could lead to memory usage growing
+      without bound by using keys in the workqueue that can be compared for equality to de-duplicate them.
+    issueLink: https://github.com/solo-io/gloo/issues/2361
+    resolvesIssue: false

--- a/pkg/api/v1/clients/kube/controller/controller.go
+++ b/pkg/api/v1/clients/kube/controller/controller.go
@@ -121,14 +121,14 @@ func (c *Controller) processNextWorkItem() bool {
 		// put back on the workqueue and attempted again after a back-off
 		// period.
 		defer c.workQueue.Done(obj)
-		var w *event
+		var e event
 		var ok bool
 		// We expect strings to come off the workqueue. These are of the
 		// form namespace/name. We do this as the delayed nature of the
 		// workqueue means the items in the informer cache may actually be
 		// more up to date that when the item was initially put onto the
 		// workqueue.
-		if w, ok = obj.(*event); !ok {
+		if e, ok = obj.(event); !ok {
 			// As the item in the workqueue is actually invalid, we call
 			// Forget here else we'd go into a loop of attempting to
 			// process a work item that is invalid.
@@ -136,13 +136,13 @@ func (c *Controller) processNextWorkItem() bool {
 			runtime.HandleError(fmt.Errorf("expected event type in workqueue but got %#v", obj))
 			return nil
 		}
-		switch w.eventType {
+		switch e.eventType {
 		case added:
-			c.handler.OnAdd(w.new)
+			c.handler.OnAdd(e.new)
 		case updated:
-			c.handler.OnUpdate(w.old, w.new)
+			c.handler.OnUpdate(e.old, e.new)
 		case deleted:
-			c.handler.OnDelete(w.new)
+			c.handler.OnDelete(e.new)
 		}
 
 		c.workQueue.Forget(obj)
@@ -174,7 +174,7 @@ func (c *Controller) eventHandlerFunctions() cache.ResourceEventHandlerFuncs {
 
 // Adds events to the work queue
 func (c *Controller) enqueueSync(t eventType, old, new interface{}) {
-	e := &event{
+	e := event{
 		eventType: t,
 		old:       old,
 		new:       new,

--- a/pkg/api/v1/clients/mocks/client_interface.go
+++ b/pkg/api/v1/clients/mocks/client_interface.go
@@ -12,30 +12,30 @@ import (
 	resources "github.com/solo-io/solo-kit/pkg/api/v1/resources"
 )
 
-// MockResourceWatcher is a mock of ResourceWatcher interface
+// MockResourceWatcher is a mock of ResourceWatcher interface.
 type MockResourceWatcher struct {
 	ctrl     *gomock.Controller
 	recorder *MockResourceWatcherMockRecorder
 }
 
-// MockResourceWatcherMockRecorder is the mock recorder for MockResourceWatcher
+// MockResourceWatcherMockRecorder is the mock recorder for MockResourceWatcher.
 type MockResourceWatcherMockRecorder struct {
 	mock *MockResourceWatcher
 }
 
-// NewMockResourceWatcher creates a new mock instance
+// NewMockResourceWatcher creates a new mock instance.
 func NewMockResourceWatcher(ctrl *gomock.Controller) *MockResourceWatcher {
 	mock := &MockResourceWatcher{ctrl: ctrl}
 	mock.recorder = &MockResourceWatcherMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResourceWatcher) EXPECT() *MockResourceWatcherMockRecorder {
 	return m.recorder
 }
 
-// Watch mocks base method
+// Watch mocks base method.
 func (m *MockResourceWatcher) Watch(namespace string, opts clients.WatchOpts) (<-chan resources.ResourceList, <-chan error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Watch", namespace, opts)
@@ -45,36 +45,36 @@ func (m *MockResourceWatcher) Watch(namespace string, opts clients.WatchOpts) (<
 	return ret0, ret1, ret2
 }
 
-// Watch indicates an expected call of Watch
+// Watch indicates an expected call of Watch.
 func (mr *MockResourceWatcherMockRecorder) Watch(namespace, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockResourceWatcher)(nil).Watch), namespace, opts)
 }
 
-// MockResourceClient is a mock of ResourceClient interface
+// MockResourceClient is a mock of ResourceClient interface.
 type MockResourceClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockResourceClientMockRecorder
 }
 
-// MockResourceClientMockRecorder is the mock recorder for MockResourceClient
+// MockResourceClientMockRecorder is the mock recorder for MockResourceClient.
 type MockResourceClientMockRecorder struct {
 	mock *MockResourceClient
 }
 
-// NewMockResourceClient creates a new mock instance
+// NewMockResourceClient creates a new mock instance.
 func NewMockResourceClient(ctrl *gomock.Controller) *MockResourceClient {
 	mock := &MockResourceClient{ctrl: ctrl}
 	mock.recorder = &MockResourceClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResourceClient) EXPECT() *MockResourceClientMockRecorder {
 	return m.recorder
 }
 
-// Kind mocks base method
+// Kind mocks base method.
 func (m *MockResourceClient) Kind() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Kind")
@@ -82,13 +82,13 @@ func (m *MockResourceClient) Kind() string {
 	return ret0
 }
 
-// Kind indicates an expected call of Kind
+// Kind indicates an expected call of Kind.
 func (mr *MockResourceClientMockRecorder) Kind() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kind", reflect.TypeOf((*MockResourceClient)(nil).Kind))
 }
 
-// NewResource mocks base method
+// NewResource mocks base method.
 func (m *MockResourceClient) NewResource() resources.Resource {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewResource")
@@ -96,13 +96,13 @@ func (m *MockResourceClient) NewResource() resources.Resource {
 	return ret0
 }
 
-// NewResource indicates an expected call of NewResource
+// NewResource indicates an expected call of NewResource.
 func (mr *MockResourceClientMockRecorder) NewResource() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewResource", reflect.TypeOf((*MockResourceClient)(nil).NewResource))
 }
 
-// Register mocks base method
+// Register mocks base method.
 func (m *MockResourceClient) Register() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Register")
@@ -110,13 +110,13 @@ func (m *MockResourceClient) Register() error {
 	return ret0
 }
 
-// Register indicates an expected call of Register
+// Register indicates an expected call of Register.
 func (mr *MockResourceClientMockRecorder) Register() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockResourceClient)(nil).Register))
 }
 
-// Read mocks base method
+// Read mocks base method.
 func (m *MockResourceClient) Read(namespace, name string, opts clients.ReadOpts) (resources.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Read", namespace, name, opts)
@@ -125,13 +125,13 @@ func (m *MockResourceClient) Read(namespace, name string, opts clients.ReadOpts)
 	return ret0, ret1
 }
 
-// Read indicates an expected call of Read
+// Read indicates an expected call of Read.
 func (mr *MockResourceClientMockRecorder) Read(namespace, name, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockResourceClient)(nil).Read), namespace, name, opts)
 }
 
-// Write mocks base method
+// Write mocks base method.
 func (m *MockResourceClient) Write(resource resources.Resource, opts clients.WriteOpts) (resources.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", resource, opts)
@@ -140,13 +140,13 @@ func (m *MockResourceClient) Write(resource resources.Resource, opts clients.Wri
 	return ret0, ret1
 }
 
-// Write indicates an expected call of Write
+// Write indicates an expected call of Write.
 func (mr *MockResourceClientMockRecorder) Write(resource, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockResourceClient)(nil).Write), resource, opts)
 }
 
-// Delete mocks base method
+// Delete mocks base method.
 func (m *MockResourceClient) Delete(namespace, name string, opts clients.DeleteOpts) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", namespace, name, opts)
@@ -154,13 +154,13 @@ func (m *MockResourceClient) Delete(namespace, name string, opts clients.DeleteO
 	return ret0
 }
 
-// Delete indicates an expected call of Delete
+// Delete indicates an expected call of Delete.
 func (mr *MockResourceClientMockRecorder) Delete(namespace, name, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockResourceClient)(nil).Delete), namespace, name, opts)
 }
 
-// List mocks base method
+// List mocks base method.
 func (m *MockResourceClient) List(namespace string, opts clients.ListOpts) (resources.ResourceList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", namespace, opts)
@@ -169,13 +169,13 @@ func (m *MockResourceClient) List(namespace string, opts clients.ListOpts) (reso
 	return ret0, ret1
 }
 
-// List indicates an expected call of List
+// List indicates an expected call of List.
 func (mr *MockResourceClientMockRecorder) List(namespace, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockResourceClient)(nil).List), namespace, opts)
 }
 
-// Watch mocks base method
+// Watch mocks base method.
 func (m *MockResourceClient) Watch(namespace string, opts clients.WatchOpts) (<-chan resources.ResourceList, <-chan error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Watch", namespace, opts)
@@ -185,42 +185,42 @@ func (m *MockResourceClient) Watch(namespace string, opts clients.WatchOpts) (<-
 	return ret0, ret1, ret2
 }
 
-// Watch indicates an expected call of Watch
+// Watch indicates an expected call of Watch.
 func (mr *MockResourceClientMockRecorder) Watch(namespace, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockResourceClient)(nil).Watch), namespace, opts)
 }
 
-// MockStorageWriteOpts is a mock of StorageWriteOpts interface
+// MockStorageWriteOpts is a mock of StorageWriteOpts interface.
 type MockStorageWriteOpts struct {
 	ctrl     *gomock.Controller
 	recorder *MockStorageWriteOptsMockRecorder
 }
 
-// MockStorageWriteOptsMockRecorder is the mock recorder for MockStorageWriteOpts
+// MockStorageWriteOptsMockRecorder is the mock recorder for MockStorageWriteOpts.
 type MockStorageWriteOptsMockRecorder struct {
 	mock *MockStorageWriteOpts
 }
 
-// NewMockStorageWriteOpts creates a new mock instance
+// NewMockStorageWriteOpts creates a new mock instance.
 func NewMockStorageWriteOpts(ctrl *gomock.Controller) *MockStorageWriteOpts {
 	mock := &MockStorageWriteOpts{ctrl: ctrl}
 	mock.recorder = &MockStorageWriteOptsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStorageWriteOpts) EXPECT() *MockStorageWriteOptsMockRecorder {
 	return m.recorder
 }
 
-// StorageWriteOptsTag mocks base method
+// StorageWriteOptsTag mocks base method.
 func (m *MockStorageWriteOpts) StorageWriteOptsTag() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "StorageWriteOptsTag")
 }
 
-// StorageWriteOptsTag indicates an expected call of StorageWriteOptsTag
+// StorageWriteOptsTag indicates an expected call of StorageWriteOptsTag.
 func (mr *MockStorageWriteOptsMockRecorder) StorageWriteOptsTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageWriteOptsTag", reflect.TypeOf((*MockStorageWriteOpts)(nil).StorageWriteOptsTag))

--- a/pkg/api/v1/clients/multicluster/factory/mocks/cluster_client_factory.go
+++ b/pkg/api/v1/clients/multicluster/factory/mocks/cluster_client_factory.go
@@ -12,30 +12,30 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
-// MockClusterClientFactory is a mock of ClusterClientFactory interface
+// MockClusterClientFactory is a mock of ClusterClientFactory interface.
 type MockClusterClientFactory struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterClientFactoryMockRecorder
 }
 
-// MockClusterClientFactoryMockRecorder is the mock recorder for MockClusterClientFactory
+// MockClusterClientFactoryMockRecorder is the mock recorder for MockClusterClientFactory.
 type MockClusterClientFactoryMockRecorder struct {
 	mock *MockClusterClientFactory
 }
 
-// NewMockClusterClientFactory creates a new mock instance
+// NewMockClusterClientFactory creates a new mock instance.
 func NewMockClusterClientFactory(ctrl *gomock.Controller) *MockClusterClientFactory {
 	mock := &MockClusterClientFactory{ctrl: ctrl}
 	mock.recorder = &MockClusterClientFactoryMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClusterClientFactory) EXPECT() *MockClusterClientFactoryMockRecorder {
 	return m.recorder
 }
 
-// GetClient mocks base method
+// GetClient mocks base method.
 func (m *MockClusterClientFactory) GetClient(cluster string, restConfig *rest.Config) (clients.ResourceClient, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClient", cluster, restConfig)
@@ -44,7 +44,7 @@ func (m *MockClusterClientFactory) GetClient(cluster string, restConfig *rest.Co
 	return ret0, ret1
 }
 
-// GetClient indicates an expected call of GetClient
+// GetClient indicates an expected call of GetClient.
 func (mr *MockClusterClientFactoryMockRecorder) GetClient(cluster, restConfig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClient", reflect.TypeOf((*MockClusterClientFactory)(nil).GetClient), cluster, restConfig)

--- a/pkg/api/v1/clients/multicluster/mocks/client_manager.go
+++ b/pkg/api/v1/clients/multicluster/mocks/client_manager.go
@@ -11,77 +11,77 @@ import (
 	clients "github.com/solo-io/solo-kit/pkg/api/v1/clients"
 )
 
-// MockClientForClusterHandler is a mock of ClientForClusterHandler interface
+// MockClientForClusterHandler is a mock of ClientForClusterHandler interface.
 type MockClientForClusterHandler struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientForClusterHandlerMockRecorder
 }
 
-// MockClientForClusterHandlerMockRecorder is the mock recorder for MockClientForClusterHandler
+// MockClientForClusterHandlerMockRecorder is the mock recorder for MockClientForClusterHandler.
 type MockClientForClusterHandlerMockRecorder struct {
 	mock *MockClientForClusterHandler
 }
 
-// NewMockClientForClusterHandler creates a new mock instance
+// NewMockClientForClusterHandler creates a new mock instance.
 func NewMockClientForClusterHandler(ctrl *gomock.Controller) *MockClientForClusterHandler {
 	mock := &MockClientForClusterHandler{ctrl: ctrl}
 	mock.recorder = &MockClientForClusterHandlerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClientForClusterHandler) EXPECT() *MockClientForClusterHandlerMockRecorder {
 	return m.recorder
 }
 
-// HandleNewClusterClient mocks base method
+// HandleNewClusterClient mocks base method.
 func (m *MockClientForClusterHandler) HandleNewClusterClient(cluster string, client clients.ResourceClient) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "HandleNewClusterClient", cluster, client)
 }
 
-// HandleNewClusterClient indicates an expected call of HandleNewClusterClient
+// HandleNewClusterClient indicates an expected call of HandleNewClusterClient.
 func (mr *MockClientForClusterHandlerMockRecorder) HandleNewClusterClient(cluster, client interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleNewClusterClient", reflect.TypeOf((*MockClientForClusterHandler)(nil).HandleNewClusterClient), cluster, client)
 }
 
-// HandleRemovedClusterClient mocks base method
+// HandleRemovedClusterClient mocks base method.
 func (m *MockClientForClusterHandler) HandleRemovedClusterClient(cluster string, client clients.ResourceClient) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "HandleRemovedClusterClient", cluster, client)
 }
 
-// HandleRemovedClusterClient indicates an expected call of HandleRemovedClusterClient
+// HandleRemovedClusterClient indicates an expected call of HandleRemovedClusterClient.
 func (mr *MockClientForClusterHandlerMockRecorder) HandleRemovedClusterClient(cluster, client interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleRemovedClusterClient", reflect.TypeOf((*MockClientForClusterHandler)(nil).HandleRemovedClusterClient), cluster, client)
 }
 
-// MockClusterClientGetter is a mock of ClusterClientGetter interface
+// MockClusterClientGetter is a mock of ClusterClientGetter interface.
 type MockClusterClientGetter struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterClientGetterMockRecorder
 }
 
-// MockClusterClientGetterMockRecorder is the mock recorder for MockClusterClientGetter
+// MockClusterClientGetterMockRecorder is the mock recorder for MockClusterClientGetter.
 type MockClusterClientGetterMockRecorder struct {
 	mock *MockClusterClientGetter
 }
 
-// NewMockClusterClientGetter creates a new mock instance
+// NewMockClusterClientGetter creates a new mock instance.
 func NewMockClusterClientGetter(ctrl *gomock.Controller) *MockClusterClientGetter {
 	mock := &MockClusterClientGetter{ctrl: ctrl}
 	mock.recorder = &MockClusterClientGetterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClusterClientGetter) EXPECT() *MockClusterClientGetterMockRecorder {
 	return m.recorder
 }
 
-// ClientForCluster mocks base method
+// ClientForCluster mocks base method.
 func (m *MockClusterClientGetter) ClientForCluster(cluster string) (clients.ResourceClient, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClientForCluster", cluster)
@@ -90,7 +90,7 @@ func (m *MockClusterClientGetter) ClientForCluster(cluster string) (clients.Reso
 	return ret0, ret1
 }
 
-// ClientForCluster indicates an expected call of ClientForCluster
+// ClientForCluster indicates an expected call of ClientForCluster.
 func (mr *MockClusterClientGetterMockRecorder) ClientForCluster(cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientForCluster", reflect.TypeOf((*MockClusterClientGetter)(nil).ClientForCluster), cluster)

--- a/pkg/api/v1/clients/wrapper/mocks/multi_watcher.go
+++ b/pkg/api/v1/clients/wrapper/mocks/multi_watcher.go
@@ -12,30 +12,30 @@ import (
 	resources "github.com/solo-io/solo-kit/pkg/api/v1/resources"
 )
 
-// MockWatchAggregator is a mock of WatchAggregator interface
+// MockWatchAggregator is a mock of WatchAggregator interface.
 type MockWatchAggregator struct {
 	ctrl     *gomock.Controller
 	recorder *MockWatchAggregatorMockRecorder
 }
 
-// MockWatchAggregatorMockRecorder is the mock recorder for MockWatchAggregator
+// MockWatchAggregatorMockRecorder is the mock recorder for MockWatchAggregator.
 type MockWatchAggregatorMockRecorder struct {
 	mock *MockWatchAggregator
 }
 
-// NewMockWatchAggregator creates a new mock instance
+// NewMockWatchAggregator creates a new mock instance.
 func NewMockWatchAggregator(ctrl *gomock.Controller) *MockWatchAggregator {
 	mock := &MockWatchAggregator{ctrl: ctrl}
 	mock.recorder = &MockWatchAggregatorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockWatchAggregator) EXPECT() *MockWatchAggregatorMockRecorder {
 	return m.recorder
 }
 
-// Watch mocks base method
+// Watch mocks base method.
 func (m *MockWatchAggregator) Watch(namespace string, opts clients.WatchOpts) (<-chan resources.ResourceList, <-chan error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Watch", namespace, opts)
@@ -45,13 +45,13 @@ func (m *MockWatchAggregator) Watch(namespace string, opts clients.WatchOpts) (<
 	return ret0, ret1, ret2
 }
 
-// Watch indicates an expected call of Watch
+// Watch indicates an expected call of Watch.
 func (mr *MockWatchAggregatorMockRecorder) Watch(namespace, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockWatchAggregator)(nil).Watch), namespace, opts)
 }
 
-// AddWatch mocks base method
+// AddWatch mocks base method.
 func (m *MockWatchAggregator) AddWatch(w clients.ResourceWatcher) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddWatch", w)
@@ -59,19 +59,19 @@ func (m *MockWatchAggregator) AddWatch(w clients.ResourceWatcher) error {
 	return ret0
 }
 
-// AddWatch indicates an expected call of AddWatch
+// AddWatch indicates an expected call of AddWatch.
 func (mr *MockWatchAggregatorMockRecorder) AddWatch(w interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWatch", reflect.TypeOf((*MockWatchAggregator)(nil).AddWatch), w)
 }
 
-// RemoveWatch mocks base method
+// RemoveWatch mocks base method.
 func (m *MockWatchAggregator) RemoveWatch(w clients.ResourceWatcher) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RemoveWatch", w)
 }
 
-// RemoveWatch indicates an expected call of RemoveWatch
+// RemoveWatch indicates an expected call of RemoveWatch.
 func (mr *MockWatchAggregatorMockRecorder) RemoveWatch(w interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveWatch", reflect.TypeOf((*MockWatchAggregator)(nil).RemoveWatch), w)

--- a/pkg/multicluster/clustercache/mocks/cache_manager.go
+++ b/pkg/multicluster/clustercache/mocks/cache_manager.go
@@ -12,65 +12,65 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
-// MockClusterCache is a mock of ClusterCache interface
+// MockClusterCache is a mock of ClusterCache interface.
 type MockClusterCache struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterCacheMockRecorder
 }
 
-// MockClusterCacheMockRecorder is the mock recorder for MockClusterCache
+// MockClusterCacheMockRecorder is the mock recorder for MockClusterCache.
 type MockClusterCacheMockRecorder struct {
 	mock *MockClusterCache
 }
 
-// NewMockClusterCache creates a new mock instance
+// NewMockClusterCache creates a new mock instance.
 func NewMockClusterCache(ctrl *gomock.Controller) *MockClusterCache {
 	mock := &MockClusterCache{ctrl: ctrl}
 	mock.recorder = &MockClusterCacheMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClusterCache) EXPECT() *MockClusterCacheMockRecorder {
 	return m.recorder
 }
 
-// IsClusterCache mocks base method
+// IsClusterCache mocks base method.
 func (m *MockClusterCache) IsClusterCache() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "IsClusterCache")
 }
 
-// IsClusterCache indicates an expected call of IsClusterCache
+// IsClusterCache indicates an expected call of IsClusterCache.
 func (mr *MockClusterCacheMockRecorder) IsClusterCache() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsClusterCache", reflect.TypeOf((*MockClusterCache)(nil).IsClusterCache))
 }
 
-// MockCacheGetter is a mock of CacheGetter interface
+// MockCacheGetter is a mock of CacheGetter interface.
 type MockCacheGetter struct {
 	ctrl     *gomock.Controller
 	recorder *MockCacheGetterMockRecorder
 }
 
-// MockCacheGetterMockRecorder is the mock recorder for MockCacheGetter
+// MockCacheGetterMockRecorder is the mock recorder for MockCacheGetter.
 type MockCacheGetterMockRecorder struct {
 	mock *MockCacheGetter
 }
 
-// NewMockCacheGetter creates a new mock instance
+// NewMockCacheGetter creates a new mock instance.
 func NewMockCacheGetter(ctrl *gomock.Controller) *MockCacheGetter {
 	mock := &MockCacheGetter{ctrl: ctrl}
 	mock.recorder = &MockCacheGetterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCacheGetter) EXPECT() *MockCacheGetterMockRecorder {
 	return m.recorder
 }
 
-// GetCache mocks base method
+// GetCache mocks base method.
 func (m *MockCacheGetter) GetCache(cluster string, restConfig *rest.Config) clustercache.ClusterCache {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCache", cluster, restConfig)
@@ -78,60 +78,60 @@ func (m *MockCacheGetter) GetCache(cluster string, restConfig *rest.Config) clus
 	return ret0
 }
 
-// GetCache indicates an expected call of GetCache
+// GetCache indicates an expected call of GetCache.
 func (mr *MockCacheGetterMockRecorder) GetCache(cluster, restConfig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCache", reflect.TypeOf((*MockCacheGetter)(nil).GetCache), cluster, restConfig)
 }
 
-// MockCacheManager is a mock of CacheManager interface
+// MockCacheManager is a mock of CacheManager interface.
 type MockCacheManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockCacheManagerMockRecorder
 }
 
-// MockCacheManagerMockRecorder is the mock recorder for MockCacheManager
+// MockCacheManagerMockRecorder is the mock recorder for MockCacheManager.
 type MockCacheManagerMockRecorder struct {
 	mock *MockCacheManager
 }
 
-// NewMockCacheManager creates a new mock instance
+// NewMockCacheManager creates a new mock instance.
 func NewMockCacheManager(ctrl *gomock.Controller) *MockCacheManager {
 	mock := &MockCacheManager{ctrl: ctrl}
 	mock.recorder = &MockCacheManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCacheManager) EXPECT() *MockCacheManagerMockRecorder {
 	return m.recorder
 }
 
-// ClusterAdded mocks base method
+// ClusterAdded mocks base method.
 func (m *MockCacheManager) ClusterAdded(cluster string, restConfig *rest.Config) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ClusterAdded", cluster, restConfig)
 }
 
-// ClusterAdded indicates an expected call of ClusterAdded
+// ClusterAdded indicates an expected call of ClusterAdded.
 func (mr *MockCacheManagerMockRecorder) ClusterAdded(cluster, restConfig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterAdded", reflect.TypeOf((*MockCacheManager)(nil).ClusterAdded), cluster, restConfig)
 }
 
-// ClusterRemoved mocks base method
+// ClusterRemoved mocks base method.
 func (m *MockCacheManager) ClusterRemoved(cluster string, restConfig *rest.Config) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ClusterRemoved", cluster, restConfig)
 }
 
-// ClusterRemoved indicates an expected call of ClusterRemoved
+// ClusterRemoved indicates an expected call of ClusterRemoved.
 func (mr *MockCacheManagerMockRecorder) ClusterRemoved(cluster, restConfig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterRemoved", reflect.TypeOf((*MockCacheManager)(nil).ClusterRemoved), cluster, restConfig)
 }
 
-// GetCache mocks base method
+// GetCache mocks base method.
 func (m *MockCacheManager) GetCache(cluster string, restConfig *rest.Config) clustercache.ClusterCache {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCache", cluster, restConfig)
@@ -139,7 +139,7 @@ func (m *MockCacheManager) GetCache(cluster string, restConfig *rest.Config) clu
 	return ret0
 }
 
-// GetCache indicates an expected call of GetCache
+// GetCache indicates an expected call of GetCache.
 func (mr *MockCacheManagerMockRecorder) GetCache(cluster, restConfig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCache", reflect.TypeOf((*MockCacheManager)(nil).GetCache), cluster, restConfig)


### PR DESCRIPTION
Drastically slows memory leak over time by ensuring that the objects keyed into the kubernetes workqueue (priority queue) are comparable so that duplicate events can be de-duplicated in [`delaying_queue.go`](https://github.com/kubernetes/client-go/blob/master/util/workqueue/delaying_queue.go#L256)