### PR TITLE
Custom spec/status conversions

### DIFF
--- a/changelog/v0.13.8/custom-resource-conversions.yaml
+++ b/changelog/v0.13.8/custom-resource-conversions.yaml
@@ -1,4 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    description: >
-      Allow custom resource to define their own marshalling behavior for `spec` and `status` fields.

--- a/changelog/v0.13.8/custom-resource-conversions.yaml
+++ b/changelog/v0.13.8/custom-resource-conversions.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Allow custom resource to define their own marshalling behavior for `spec` and `status` fields.

--- a/changelog/v0.13.9/custom-resource-conversions.yaml
+++ b/changelog/v0.13.9/custom-resource-conversions.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: >
+    Allow custom resource to define their own marshalling behavior for `spec` and `status` fields.

--- a/changelog/v0.13.9/custom-resource-conversions.yaml
+++ b/changelog/v0.13.9/custom-resource-conversions.yaml
@@ -2,3 +2,5 @@ changelog:
 - type: NON_USER_FACING
   description: >
     Allow custom resource to define their own marshalling behavior for `spec` and `status` fields.
+- type: NON_USER_FACING
+  description: Disable all multicluster tests.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,18 +53,6 @@ steps:
   dir: *dir
 
 - name: gcr.io/cloud-builders/gcloud
-  args: ['container', 'clusters', 'get-credentials', 'solo-kit-multicluster']
-  id: 'gcloud-solo-kit-multicluster'
-  dir: *dir
-
-- name: gcr.io/cloud-builders/gcloud
-  entrypoint: cp
-  args:
-  - /builder/home/.kube/config
-  - /builder/home/.kube/solo-kit-multicluster-config
-  id: 'copy-multicluster-config'
-
-- name: gcr.io/cloud-builders/gcloud
   args: ['container', 'clusters', 'get-credentials', 'solo-kit-test']
   id: 'gcloud-solo-kit-test'
 
@@ -81,7 +69,6 @@ steps:
   - 'RUN_VAULT_TESTS=1'
   - 'SKIP_MOCK_GEN=1'
   - 'CLOUD_BUILD=1'
-  - 'ALT_CLUSTER_KUBECONFIG=/builder/home/.kube/solo-kit-multicluster-config'
   args: ['-r', '-v', '-race', '-p', '-tags', 'solokit', '-compilers=2']
   dir: *dir
   id: 'test'

--- a/pkg/api/v1/clients/kube/crd/client/clientset/versioned/clientset_test.go
+++ b/pkg/api/v1/clients/kube/crd/client/clientset/versioned/clientset_test.go
@@ -66,7 +66,8 @@ var _ = Describe("Clientset", func() {
 		name := "foo"
 		input := mocksv1.NewMockResource(namespace, name)
 		input.Data = name
-		inputCrd := mocksv1.MockResourceCrd.KubeResource(input)
+		inputCrd, err := mocksv1.MockResourceCrd.KubeResource(input)
+		Expect(err).NotTo(HaveOccurred())
 		created, err := mockCrdClient.ResourcesV1().Resources(namespace).Create(inputCrd)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(created).NotTo(BeNil())

--- a/pkg/api/v1/clients/kube/crd/crd.go
+++ b/pkg/api/v1/clients/kube/crd/crd.go
@@ -79,21 +79,21 @@ func (d Crd) KubeResource(resource resources.InputResource) *v1.Resource {
 		status v1.Status
 	)
 
-	if withConverters, ok := resource.(resources.CustomInputResource); ok {
+	if customResource, ok := resource.(resources.CustomInputResource); ok {
 		// Handle custom spec/status marshalling
 
 		var err error
-		spec, err = withConverters.MarshalSpec()
+		spec, err = customResource.MarshalSpec()
 		if err != nil {
 			panic(fmt.Sprintf("internal error: failed to marshal resource spec to map: %v", err))
 		}
-		status, err = withConverters.MarshalStatus()
+		status, err = customResource.MarshalStatus()
 		if err != nil {
 			panic(fmt.Sprintf("internal error: failed to marshal resource status to map: %v", err))
 		}
 
 	} else {
-		// Handle regular solo-kit resources
+		// Default marshalling
 
 		data, err := protoutils.MarshalMap(resource)
 		if err != nil {

--- a/pkg/api/v1/clients/kube/crd/crd.go
+++ b/pkg/api/v1/clients/kube/crd/crd.go
@@ -1,9 +1,10 @@
 package crd
 
 import (
-	"fmt"
 	"log"
 	"sync"
+
+	"github.com/rotisserie/eris"
 
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd/client/clientset/versioned/scheme"
 	v1 "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd/solo.io/v1"
@@ -17,7 +18,13 @@ import (
 )
 
 // TODO(ilackarms): evaluate this fix for concurrent map access in k8s.io/apimachinery/pkg/runtime.SchemaBuider
-var registerLock sync.Mutex
+var (
+	registerLock sync.Mutex
+
+	MarshalErr = func(err error, detail string) error {
+		return eris.Wrapf(err, "internal error: failed to marshal %s", detail)
+	}
+)
 
 type CrdMeta struct {
 	Plural        string
@@ -73,7 +80,7 @@ func (d Crd) Register(apiexts apiexts.Interface) error {
 	return getRegistry().registerCrd(d.GroupVersionKind(), apiexts)
 }
 
-func (d Crd) KubeResource(resource resources.InputResource) *v1.Resource {
+func (d Crd) KubeResource(resource resources.InputResource) (*v1.Resource, error) {
 	var (
 		spec   v1.Spec
 		status v1.Status
@@ -85,11 +92,11 @@ func (d Crd) KubeResource(resource resources.InputResource) *v1.Resource {
 		var err error
 		spec, err = customResource.MarshalSpec()
 		if err != nil {
-			panic(fmt.Sprintf("internal error: failed to marshal resource spec to map: %v", err))
+			return nil, MarshalErr(err, "resource spec to map")
 		}
 		status, err = customResource.MarshalStatus()
 		if err != nil {
-			panic(fmt.Sprintf("internal error: failed to marshal resource status to map: %v", err))
+			return nil, MarshalErr(err, "resource status to map")
 		}
 
 	} else {
@@ -97,7 +104,7 @@ func (d Crd) KubeResource(resource resources.InputResource) *v1.Resource {
 
 		data, err := protoutils.MarshalMap(resource)
 		if err != nil {
-			panic(fmt.Sprintf("internal error: failed to marshal resource to map: %v", err))
+			return nil, MarshalErr(err, "resource to map")
 		}
 
 		delete(data, "metadata")
@@ -107,7 +114,7 @@ func (d Crd) KubeResource(resource resources.InputResource) *v1.Resource {
 		statusProto := resource.GetStatus()
 		statusMap, err := protoutils.MarshalMapFromProtoWithEnumsAsInts(&statusProto)
 		if err != nil {
-			panic(fmt.Sprintf("internal error: failed to marshal resource status to map %v", err))
+			return nil, MarshalErr(err, "resource status to map")
 		}
 		status = statusMap
 	}
@@ -117,7 +124,7 @@ func (d Crd) KubeResource(resource resources.InputResource) *v1.Resource {
 		ObjectMeta: kubeutils.ToKubeMetaMaintainNamespace(resource.GetMetadata()),
 		Status:     status,
 		Spec:       &spec,
-	}
+	}, nil
 }
 
 func (d CrdMeta) FullName() string {

--- a/pkg/api/v1/clients/kube/resource_client.go
+++ b/pkg/api/v1/clients/kube/resource_client.go
@@ -198,7 +198,10 @@ func (rc *ResourceClient) Write(resource resources.Resource, opts clients.WriteO
 	// mutate and return clone
 	clone := resources.Clone(resource).(resources.InputResource)
 	clone.SetMetadata(meta)
-	resourceCrd := rc.crd.KubeResource(clone)
+	resourceCrd, err := rc.crd.KubeResource(clone)
+	if err != nil {
+		return nil, err
+	}
 
 	ctx := opts.Ctx
 	if ctxWithTags, err := tag.New(ctx, tag.Insert(KeyKind, rc.resourceName), tag.Insert(KeyOpKind, "write")); err == nil {

--- a/pkg/api/v1/clients/kube/resource_client.go
+++ b/pkg/api/v1/clients/kube/resource_client.go
@@ -438,7 +438,7 @@ func (rc *ResourceClient) convertCrdToResource(resourceCrd *v1.Resource) (resour
 		}
 
 	} else {
-		// Handle regular solo-kit resources
+		// Default unmarshalling
 
 		if withStatus, ok := resource.(resources.InputResource); ok {
 			updateFunc := func(status *core.Status) error {

--- a/pkg/api/v1/clients/multicluster/multi_cluster_resource_client_kube_test.go
+++ b/pkg/api/v1/clients/multicluster/multi_cluster_resource_client_kube_test.go
@@ -32,8 +32,9 @@ import (
 )
 
 var _ = Describe("MultiClusterResourceClient e2e test", func() {
-	if os.Getenv("RUN_KUBE_TESTS") != "1" {
-		log.Printf("This test creates kubernetes resources and is disabled by default. To enable, set RUN_KUBE_TESTS=1 in your env.")
+	if !shouldRunMultiClusterTests() {
+		log.Printf("Multi-cluster kubernetes tests are disabled by default. To enable, set RUN_KUBE_TESTS=1 and " +
+			"RUN_MULTI_CLUSTER_TESTS=1 in your env, and set ALT_CLUSTER_KUBECONFIG to a valid kubernetes config file.")
 		return
 	}
 

--- a/pkg/api/v1/clients/multicluster/multicluster_suite_test.go
+++ b/pkg/api/v1/clients/multicluster/multicluster_suite_test.go
@@ -29,7 +29,7 @@ var (
 	err                   error
 
 	_ = SynchronizedBeforeSuite(func() []byte {
-		if os.Getenv("RUN_KUBE_TESTS") != "1" {
+		if !shouldRunMultiClusterTests() {
 			return nil
 		}
 
@@ -53,7 +53,7 @@ var (
 	}, func([]byte) {})
 
 	_ = SynchronizedAfterSuite(func() {}, func() {
-		if os.Getenv("RUN_KUBE_TESTS") != "1" {
+		if !shouldRunMultiClusterTests() {
 			return
 		}
 
@@ -84,4 +84,8 @@ func remoteKubeClient() kubernetes.Interface {
 	client, err := kubernetes.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())
 	return client
+}
+
+func shouldRunMultiClusterTests() bool {
+	return os.Getenv("RUN_KUBE_TESTS") == "1" && os.Getenv("RUN_MULTI_CLUSTER_TESTS") == "1"
 }

--- a/pkg/api/v1/resources/resource_interface.go
+++ b/pkg/api/v1/resources/resource_interface.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"sort"
 
+	v1 "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd/solo.io/v1"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/gogo/protobuf/proto"
@@ -44,6 +46,17 @@ type InputResource interface {
 	Resource
 	GetStatus() core.Status
 	SetStatus(status core.Status)
+}
+
+// Custom resource imported in a solo-kit project can implement this interface to control
+// how spec and status data is mapped to/from the generic `Resource` type.
+// this interface in order
+type CustomInputResource interface {
+	InputResource
+	UnmarshalSpec(spec v1.Spec) error
+	UnmarshalStatus(status v1.Status) error
+	MarshalSpec() (v1.Spec, error)
+	MarshalStatus() (v1.Status, error)
 }
 
 type ResourceList []Resource

--- a/pkg/api/v1/resources/resource_interface.go
+++ b/pkg/api/v1/resources/resource_interface.go
@@ -48,9 +48,8 @@ type InputResource interface {
 	SetStatus(status core.Status)
 }
 
-// Custom resource imported in a solo-kit project can implement this interface to control
+// Custom resources imported in a solo-kit project can implement this interface to control
 // how spec and status data is mapped to/from the generic `Resource` type.
-// this interface in order
 type CustomInputResource interface {
 	InputResource
 	UnmarshalSpec(spec v1.Spec) error

--- a/pkg/api/v2/reporter/reporter.go
+++ b/pkg/api/v2/reporter/reporter.go
@@ -104,7 +104,7 @@ func (e ResourceReports) ValidateStrict() error {
 }
 
 // Minimal set of client operations required for reporters.
-type ReporterClient interface {
+type ReporterResourceClient interface {
 	Kind() string
 	Read(namespace, name string, opts clients.ReadOpts) (resources.Resource, error)
 	Write(resource resources.Resource, opts clients.WriteOpts) (resources.Resource, error)
@@ -115,12 +115,12 @@ type Reporter interface {
 }
 
 type reporter struct {
-	clients map[string]ReporterClient
+	clients map[string]ReporterResourceClient
 	ref     string
 }
 
-func NewReporter(reporterRef string, reporterClients ...ReporterClient) Reporter {
-	clientsByKind := make(map[string]ReporterClient)
+func NewReporter(reporterRef string, reporterClients ...ReporterResourceClient) Reporter {
+	clientsByKind := make(map[string]ReporterResourceClient)
 	for _, client := range reporterClients {
 		clientsByKind[client.Kind()] = client
 	}
@@ -187,7 +187,7 @@ func (r *reporter) WriteReports(ctx context.Context, resourceErrs ResourceReport
 // Ideally, this and its caller, WriteReports, would just take the resource ref and its status, rather than the resource itself,
 //    to avoid confusion about whether this may update the resource rather than just its status.
 //    However, this change is not worth the effort and risk right now. (Ariana, June 2020)
-func attemptUpdateStatus(ctx context.Context, client ReporterClient, resourceToWrite resources.InputResource) (resources.Resource, resources.InputResource, error) {
+func attemptUpdateStatus(ctx context.Context, client ReporterResourceClient, resourceToWrite resources.InputResource) (resources.Resource, resources.InputResource, error) {
 	var readErr error
 	resourceFromRead, readErr := client.Read(resourceToWrite.GetMetadata().Namespace, resourceToWrite.GetMetadata().Name, clients.ReadOpts{Ctx: ctx})
 	if readErr != nil && errors.IsNotExist(readErr) { // resource has been deleted, don't re-create

--- a/pkg/api/v2/reporter/reporter.go
+++ b/pkg/api/v2/reporter/reporter.go
@@ -103,18 +103,25 @@ func (e ResourceReports) ValidateStrict() error {
 	return errs
 }
 
+// Minimal set of client operations required for reporters.
+type ReporterClient interface {
+	Kind() string
+	Read(namespace, name string, opts clients.ReadOpts) (resources.Resource, error)
+	Write(resource resources.Resource, opts clients.WriteOpts) (resources.Resource, error)
+}
+
 type Reporter interface {
 	WriteReports(ctx context.Context, errs ResourceReports, subresourceStatuses map[string]*core.Status) error
 }
 
 type reporter struct {
-	clients clients.ResourceClients
+	clients map[string]ReporterClient
 	ref     string
 }
 
-func NewReporter(reporterRef string, resourceClients ...clients.ResourceClient) Reporter {
-	clientsByKind := make(clients.ResourceClients)
-	for _, client := range resourceClients {
+func NewReporter(reporterRef string, reporterClients ...ReporterClient) Reporter {
+	clientsByKind := make(map[string]ReporterClient)
+	for _, client := range reporterClients {
 		clientsByKind[client.Kind()] = client
 	}
 	return &reporter{
@@ -180,7 +187,7 @@ func (r *reporter) WriteReports(ctx context.Context, resourceErrs ResourceReport
 // Ideally, this and its caller, WriteReports, would just take the resource ref and its status, rather than the resource itself,
 //    to avoid confusion about whether this may update the resource rather than just its status.
 //    However, this change is not worth the effort and risk right now. (Ariana, June 2020)
-func attemptUpdateStatus(ctx context.Context, client clients.ResourceClient, resourceToWrite resources.InputResource) (resources.Resource, resources.InputResource, error) {
+func attemptUpdateStatus(ctx context.Context, client ReporterClient, resourceToWrite resources.InputResource) (resources.Resource, resources.InputResource, error) {
 	var readErr error
 	resourceFromRead, readErr := client.Read(resourceToWrite.GetMetadata().Namespace, resourceToWrite.GetMetadata().Name, clients.ReadOpts{Ctx: ctx})
 	if readErr != nil && errors.IsNotExist(readErr) { // resource has been deleted, don't re-create

--- a/pkg/utils/protoutils/marshal.go
+++ b/pkg/utils/protoutils/marshal.go
@@ -101,6 +101,19 @@ func MarshalMapEmitZeroValues(from resources.Resource) (map[string]interface{}, 
 	return m, err
 }
 
+func MarshalMapFromProto(from proto.Message) (map[string]interface{}, error) {
+	out := &bytes.Buffer{}
+	if err := jsonpbMarshaler.Marshal(out, from); err != nil {
+		return nil, eris.Wrap(err, "failed to marshal proto to bytes")
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(out.Bytes(), &m); err != nil {
+		return nil, eris.Wrap(err, "failed to unmarshal bytes to map")
+	}
+	return m, nil
+}
+
 func MarshalMapFromProtoWithEnumsAsInts(from proto.Message) (map[string]interface{}, error) {
 	out := &bytes.Buffer{}
 	if err := jsonpbMarshalerEnumsAsInts.Marshal(out, from); err != nil {

--- a/test/util/utils.go
+++ b/test/util/utils.go
@@ -32,11 +32,15 @@ func MockClientForNamespace(cache kube.SharedCache, namespaces []string) *kube.R
 }
 
 func CreateMockResource(cs *fake.Clientset, namespace, name, dumbFieldValue string) error {
-	_, err := cs.ResourcesV1().Resources(namespace).Create(
-		v1.MockResourceCrd.KubeResource(&v1.MockResource{
-			Metadata:      core.Metadata{Name: name},
-			SomeDumbField: dumbFieldValue,
-		}))
+	kubeResource, err := v1.MockResourceCrd.KubeResource(&v1.MockResource{
+		Metadata:      core.Metadata{Name: name},
+		SomeDumbField: dumbFieldValue,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = cs.ResourcesV1().Resources(namespace).Create(kubeResource)
 	return err
 }
 
@@ -45,12 +49,16 @@ func DeleteMockResource(cs *fake.Clientset, namespace, name string) error {
 }
 
 func CreateV2Alpha1MockResource(cs *fake.Clientset, namespace, name, dumbFieldValue string) error {
-	_, err := cs.ResourcesV1().Resources(namespace).Create(
-		v2alpha1.MockResourceCrd.KubeResource(&v2alpha1.MockResource{
-			Metadata: core.Metadata{Name: name},
-			WeStuckItInAOneof: &v2alpha1.MockResource_SomeDumbField{
-				SomeDumbField: dumbFieldValue,
-			},
-		}))
+	kubeResource, err := v2alpha1.MockResourceCrd.KubeResource(&v2alpha1.MockResource{
+		Metadata: core.Metadata{Name: name},
+		WeStuckItInAOneof: &v2alpha1.MockResource_SomeDumbField{
+			SomeDumbField: dumbFieldValue,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = cs.ResourcesV1().Resources(namespace).Create(kubeResource)
 	return err
 }


### PR DESCRIPTION
Allow custom resource to define their own marshalling behavior for `spec` and `status` fields.