### PR TITLE
Fix snapshot channel closesure to only run once.

### DIFF
--- a/changelog/v0.14.2/move-snapshot-closure-function.yaml
+++ b/changelog/v0.14.2/move-snapshot-closure-function.yaml
@@ -1,3 +1,4 @@
 changelog:
 - type: FIX
   description: Only run deferred function to close channel in the snapshot emitter once.
+  issueLink: https://github.com/solo-io/solo-kit/issues/391  

--- a/changelog/v0.14.2/move-snapshot-closure-function.yaml
+++ b/changelog/v0.14.2/move-snapshot-closure-function.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: FIX
+  description: Only run deferred function to close channel in the snapshot emitter once.

--- a/pkg/code-generator/codegen/templates/kube/generate_script.go
+++ b/pkg/code-generator/codegen/templates/kube/generate_script.go
@@ -46,7 +46,7 @@ ${CODEGEN_PKG}/generate-groups.sh all \
     ${CLIENT_PKG} \
     ${APIS_PKG} \
     {{ .ProjectConfig.Name }}:{{ .ProjectConfig.Version }} \
-    --output-base "${TEMP_DIR}"
+    --output-base "${TEMP_DIR}" --go-header-file "${CODEGEN_PKG}/hack/boilerplate.go.txt"
 # Copy everything back.
 cp -a "${TEMP_DIR}/${ROOT_PKG}/." "${SCRIPT_ROOT}/.."
 

--- a/pkg/code-generator/codegen/templates/snapshot_emitter_template.go
+++ b/pkg/code-generator/codegen/templates/snapshot_emitter_template.go
@@ -287,16 +287,15 @@ func (c *{{ lower_camel .GoName }}Emitter) Snapshots(watchNamespaces []string, o
 				{{ lower_camel .PluralName }}ByNamespace := make(map[string]{{ .ImportPrefix }}{{ .Name }}List)
 		{{- end }}
 		{{- end }}
-
+		defer func() {
+			close(snapshots)
+			// we must wait for done before closing the error chan,
+			// to avoid sending on close channel.
+			done.Wait()
+			close(errs)
+		}()
 		for {
 			record := func(){stats.Record(ctx, m{{ $resource_group }}SnapshotIn.M(1))}
-			defer func() {
-				close(snapshots)
-				// we must wait for done before closing the error chan,
-				// to avoid sending on close channel.
-				done.Wait()
-				close(errs)
-			}()
 			
 			select {
 			case <-timer.C:

--- a/pkg/multicluster/v1/kubeconfigs_snapshot_emitter.sk.go
+++ b/pkg/multicluster/v1/kubeconfigs_snapshot_emitter.sk.go
@@ -210,16 +210,15 @@ func (c *kubeconfigsEmitter) Snapshots(watchNamespaces []string, opts clients.Wa
 			}
 		}
 		kubeconfigsByNamespace := make(map[string]KubeConfigList)
-
+		defer func() {
+			close(snapshots)
+			// we must wait for done before closing the error chan,
+			// to avoid sending on close channel.
+			done.Wait()
+			close(errs)
+		}()
 		for {
 			record := func() { stats.Record(ctx, mKubeconfigsSnapshotIn.M(1)) }
-			defer func() {
-				close(snapshots)
-				// we must wait for done before closing the error chan,
-				// to avoid sending on close channel.
-				done.Wait()
-				close(errs)
-			}()
 
 			select {
 			case <-timer.C:

--- a/test/mocks/v1/testing_snapshot_emitter.sk.go
+++ b/test/mocks/v1/testing_snapshot_emitter.sk.go
@@ -430,16 +430,15 @@ func (c *testingEmitter) Snapshots(watchNamespaces []string, opts clients.WatchO
 		anothermockresourcesByNamespace := make(map[string]AnotherMockResourceList)
 		mctsByNamespace := make(map[string]MockCustomTypeList)
 		podsByNamespace := make(map[string]github_com_solo_io_solo_kit_pkg_api_v1_resources_common_kubernetes.PodList)
-
+		defer func() {
+			close(snapshots)
+			// we must wait for done before closing the error chan,
+			// to avoid sending on close channel.
+			done.Wait()
+			close(errs)
+		}()
 		for {
 			record := func() { stats.Record(ctx, mTestingSnapshotIn.M(1)) }
-			defer func() {
-				close(snapshots)
-				// we must wait for done before closing the error chan,
-				// to avoid sending on close channel.
-				done.Wait()
-				close(errs)
-			}()
 
 			select {
 			case <-timer.C:

--- a/test/mocks/v1alpha1/testing_snapshot_emitter.sk.go
+++ b/test/mocks/v1alpha1/testing_snapshot_emitter.sk.go
@@ -210,16 +210,15 @@ func (c *testingEmitter) Snapshots(watchNamespaces []string, opts clients.WatchO
 			}
 		}
 		mocksByNamespace := make(map[string]MockResourceList)
-
+		defer func() {
+			close(snapshots)
+			// we must wait for done before closing the error chan,
+			// to avoid sending on close channel.
+			done.Wait()
+			close(errs)
+		}()
 		for {
 			record := func() { stats.Record(ctx, mTestingSnapshotIn.M(1)) }
-			defer func() {
-				close(snapshots)
-				// we must wait for done before closing the error chan,
-				// to avoid sending on close channel.
-				done.Wait()
-				close(errs)
-			}()
 
 			select {
 			case <-timer.C:

--- a/test/mocks/v2alpha1/kube/hack/update-codegen.sh
+++ b/test/mocks/v2alpha1/kube/hack/update-codegen.sh
@@ -37,7 +37,7 @@ ${CODEGEN_PKG}/generate-groups.sh all \
     ${CLIENT_PKG} \
     ${APIS_PKG} \
     testing.solo.io:v2alpha1 \
-    --output-base "${TEMP_DIR}"
+    --output-base "${TEMP_DIR}" --go-header-file "${CODEGEN_PKG}/hack/boilerplate.go.txt"
 # Copy everything back.
 cp -a "${TEMP_DIR}/${ROOT_PKG}/." "${SCRIPT_ROOT}/.."
 

--- a/test/mocks/v2alpha1/testing_snapshot_emitter.sk.go
+++ b/test/mocks/v2alpha1/testing_snapshot_emitter.sk.go
@@ -308,16 +308,15 @@ func (c *testingEmitter) Snapshots(watchNamespaces []string, opts clients.WatchO
 		mocksByNamespace := make(map[string]MockResourceList)
 		fcarsByNamespace := make(map[string]FrequentlyChangingAnnotationsResourceList)
 		fakesByNamespace := make(map[string]testing_solo_io.FakeResourceList)
-
+		defer func() {
+			close(snapshots)
+			// we must wait for done before closing the error chan,
+			// to avoid sending on close channel.
+			done.Wait()
+			close(errs)
+		}()
 		for {
 			record := func() { stats.Record(ctx, mTestingSnapshotIn.M(1)) }
-			defer func() {
-				close(snapshots)
-				// we must wait for done before closing the error chan,
-				// to avoid sending on close channel.
-				done.Wait()
-				close(errs)
-			}()
 
 			select {
 			case <-timer.C:


### PR DESCRIPTION
The snapshot emitted has a snapshot channel, whose closure function was inside a for-loop, which allowed it to run more than once and cause problems. This moves that defer function out of the for loop, so it only gets called once.

This also corrects a minor error in the generate code script.

issuelink: https://github.com/solo-io/solo-kit/issues/391
BOT NOTES: 
resolves https://github.com/solo-io/solo-kit/issues/391