### PR TITLE
Set snapshot fix

### DIFF
--- a/changelog/v0.18.2/set-snapshot-fix.yaml
+++ b/changelog/v0.18.2/set-snapshot-fix.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    description: >
+      Set snapshot will send a response for a resource only if that snapshot resource has been set.
+    issueLink: https://github.com/solo-io/gloo/issues/4084
+    resolvesIssue: false

--- a/changelog/v0.18.2/set-snapshot-fix.yaml
+++ b/changelog/v0.18.2/set-snapshot-fix.yaml
@@ -2,5 +2,5 @@ changelog:
   - type: FIX
     description: >
       Set snapshot will send a response for a resource only if that snapshot resource has been set.
-    issueLink: https://github.com/solo-io/gloo/issues/4084
+    issueLink: https://github.com/solo-io/gloo/issues/4345
     resolvesIssue: false

--- a/go.sum
+++ b/go.sum
@@ -1236,6 +1236,7 @@ k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 h1:Oh3Mzx5pJ+yIumsAD0MOECPVeXsVot0UkiaCGVyfGQY=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kubectl v0.18.0/go.mod h1:LOkWx9Z5DXMEg5KtOjHhRiC1fqJPLyCr3KtQgEolCkU=
+k8s.io/kubernetes v1.13.0 h1:qTfB+u5M92k2fCCCVP2iuhgwwSOv1EkAkvQY1tQODD8=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/metrics v0.18.0/go.mod h1:8aYTW18koXqjLVKL7Ds05RPMX9ipJZI3mywYvBOxXd4=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/pkg/api/v1/control-plane/cache/cache_suite_test.go
+++ b/pkg/api/v1/control-plane/cache/cache_suite_test.go
@@ -2,6 +2,9 @@ package cache_test
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v32 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -14,8 +17,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/solo-io/solo-kit/pkg/api/v1/control-plane/cache"
 	"github.com/solo-io/solo-kit/pkg/api/v1/control-plane/resource"
-	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/pkg/api/v1/control-plane/cache/cache_suite_test.go
+++ b/pkg/api/v1/control-plane/cache/cache_suite_test.go
@@ -1,7 +1,21 @@
-package cache
+package cache_test
 
 import (
+	"fmt"
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v32 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/solo-io/solo-kit/pkg/api/v1/control-plane/cache"
+	"github.com/solo-io/solo-kit/pkg/api/v1/control-plane/resource"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -10,4 +24,205 @@ import (
 func TestControlPlaneCache(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "ControlPlaneCache Suite")
+}
+
+const (
+	ListenerName = "listener_0"
+	UpstreamHost = "127.0.0.1"
+)
+
+type TestSnapshot struct {
+	// Endpoints are items in the EDS V3 response payload.
+	Endpoints cache.Resources
+
+	// Clusters are items in the CDS response payload.
+	Clusters cache.Resources
+
+	// Routes are items in the RDS response payload.
+	Routes cache.Resources
+
+	// Listeners are items in the LDS response payload.
+	Listeners cache.Resources
+}
+
+func (s TestSnapshot) Consistent() error {
+	endpoints := resource.GetResourceReferences(s.Clusters.Items)
+	if len(endpoints) != len(s.Endpoints.Items) {
+		return fmt.Errorf("mismatched endpoint reference and resource lengths: length of %v does not equal length of %v", endpoints, s.Endpoints.Items)
+	}
+	if err := cache.Superset(endpoints, s.Endpoints.Items); err != nil {
+		return err
+	}
+
+	routes := resource.GetResourceReferences(s.Listeners.Items)
+	if len(routes) != len(s.Routes.Items) {
+		return fmt.Errorf("mismatched route reference and resource lengths: length of %v does not equal length of %v", routes, s.Routes.Items)
+	}
+	return cache.Superset(routes, s.Routes.Items)
+}
+func (s TestSnapshot) GetResources(typ string) cache.Resources {
+	switch typ {
+	case resource.EndpointTypeV3:
+		return s.Endpoints
+	case resource.ClusterTypeV3:
+		return s.Clusters
+	case resource.RouteTypeV3:
+		return s.Routes
+	case resource.ListenerTypeV3:
+		return s.Listeners
+	}
+	return cache.Resources{}
+}
+func (s TestSnapshot) Clone() cache.Snapshot {
+	snapshotClone := &TestSnapshot{}
+
+	snapshotClone.Endpoints = cache.Resources{
+		Version: s.Endpoints.Version,
+		Items:   cloneItems(s.Endpoints.Items),
+	}
+
+	snapshotClone.Clusters = cache.Resources{
+		Version: s.Clusters.Version,
+		Items:   cloneItems(s.Clusters.Items),
+	}
+
+	snapshotClone.Routes = cache.Resources{
+		Version: s.Routes.Version,
+		Items:   cloneItems(s.Routes.Items),
+	}
+
+	snapshotClone.Listeners = cache.Resources{
+		Version: s.Listeners.Version,
+		Items:   cloneItems(s.Listeners.Items),
+	}
+
+	return snapshotClone
+}
+
+func cloneItems(items map[string]cache.Resource) map[string]cache.Resource {
+	clonedItems := make(map[string]cache.Resource, len(items))
+	for k, v := range items {
+		resProto := v.ResourceProto()
+		resClone := proto.Clone(resProto)
+		clonedItems[k] = resource.NewEnvoyResource(resClone)
+	}
+	return clonedItems
+}
+
+var _ cache.Snapshot = TestSnapshot{}
+
+func makeEndpoint(clusterName string) *endpoint.ClusterLoadAssignment {
+	return &endpoint.ClusterLoadAssignment{
+		ClusterName: clusterName,
+		Endpoints: []*endpoint.LocalityLbEndpoints{{
+			LbEndpoints: []*endpoint.LbEndpoint{{
+				HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+					Endpoint: &endpoint.Endpoint{
+						Address: &core.Address{
+							Address: &core.Address_SocketAddress{
+								SocketAddress: &core.SocketAddress{
+									Protocol: core.SocketAddress_TCP,
+									Address:  UpstreamHost,
+									PortSpecifier: &core.SocketAddress_PortValue{
+										PortValue: uint32(8080),
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
+		}},
+	}
+}
+
+func makeEDSCluster(clusterName string) *cluster.Cluster {
+	return &cluster.Cluster{
+		Name:                 clusterName,
+		ConnectTimeout:       ptypes.DurationProto(5 * time.Second),
+		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
+		LbPolicy:             cluster.Cluster_ROUND_ROBIN,
+		LoadAssignment:       makeEndpoint(clusterName),
+		DnsLookupFamily:      cluster.Cluster_V4_ONLY,
+		EdsClusterConfig: &cluster.Cluster_EdsClusterConfig{
+			EdsConfig: &v32.ConfigSource{
+				ConfigSourceSpecifier: &v32.ConfigSource_Ads{
+					Ads: &v32.AggregatedConfigSource{},
+				},
+			},
+		},
+	}
+}
+
+func makeCluster(clusterName string) *cluster.Cluster {
+	return &cluster.Cluster{
+		Name:                 clusterName,
+		ConnectTimeout:       ptypes.DurationProto(5 * time.Second),
+		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_LOGICAL_DNS},
+		LbPolicy:             cluster.Cluster_ROUND_ROBIN,
+		LoadAssignment:       makeEndpoint(clusterName),
+		DnsLookupFamily:      cluster.Cluster_V4_ONLY,
+	}
+}
+
+func makeRoute(routeName string, clusterName string) *route.RouteConfiguration {
+	routeConfiguration := &route.RouteConfiguration{
+		Name: routeName,
+		VirtualHosts: []*route.VirtualHost{{
+			Name:    "local_service",
+			Domains: []string{"*"},
+		}},
+	}
+	routeConfiguration.VirtualHosts[0].Routes = []*route.Route{{
+		Match: &route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_Prefix{
+				Prefix: "/",
+			},
+		},
+		Action: &route.Route_Route{
+			Route: &route.RouteAction{
+				ClusterSpecifier: &route.RouteAction_Cluster{
+					Cluster: clusterName,
+				},
+				HostRewriteSpecifier: &route.RouteAction_HostRewriteLiteral{
+					HostRewriteLiteral: UpstreamHost,
+				},
+			},
+		},
+	}}
+	return routeConfiguration
+}
+
+func makeHTTPListener(route string) *listener.Listener {
+	// HTTP filter configuration
+	manager := &hcm.HttpConnectionManager{
+		CodecType:  hcm.HttpConnectionManager_AUTO,
+		StatPrefix: "http",
+		RouteSpecifier: &hcm.HttpConnectionManager_Rds{
+			Rds: &hcm.Rds{
+				ConfigSource:    &core.ConfigSource{},
+				RouteConfigName: route,
+			},
+		},
+		HttpFilters: []*hcm.HttpFilter{{
+			Name: wellknown.Router,
+		}},
+	}
+	pbst, err := ptypes.MarshalAny(manager)
+	if err != nil {
+		panic(err)
+	}
+
+	return &listener.Listener{
+		Name:    ListenerName,
+		Address: &core.Address{},
+		FilterChains: []*listener.FilterChain{{
+			Filters: []*listener.Filter{{
+				Name: wellknown.HTTPConnectionManager,
+				ConfigType: &listener.Filter_TypedConfig{
+					TypedConfig: pbst,
+				},
+			}},
+		}},
+	}
 }

--- a/pkg/api/v1/control-plane/cache/cache_test.go
+++ b/pkg/api/v1/control-plane/cache/cache_test.go
@@ -2,7 +2,6 @@ package cache_test
 
 import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	rsrc "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/solo-kit/pkg/api/v1/control-plane/cache"
@@ -59,19 +58,17 @@ var _ = Describe("Control Plane Cache", func() {
 
 	It("Setting snapshot correctly updates the version", func() {
 		names := map[string][]string{
-			rsrc.EndpointType: {clusterName},
-			rsrc.ClusterType:  nil,
-			rsrc.RouteType:    {routeName},
-			rsrc.ListenerType: nil,
-			rsrc.RuntimeType:  nil,
+			resource.EndpointTypeV3: {clusterName},
+			resource.ClusterTypeV3:  nil,
+			resource.RouteTypeV3:    {routeName},
+			resource.ListenerTypeV3: nil,
 		}
 
 		testTypes := []string{
-			rsrc.EndpointType,
-			rsrc.ClusterType,
-			rsrc.RouteType,
-			rsrc.ListenerType,
-			rsrc.RuntimeType,
+			resource.EndpointTypeV3,
+			resource.ClusterTypeV3,
+			resource.RouteTypeV3,
+			resource.ListenerTypeV3,
 		}
 
 		c := cache.NewSnapshotCache(true, TestIDHash{}, nil)
@@ -112,11 +109,11 @@ var _ = Describe("Control Plane Cache", func() {
 		snap, err := c.GetSnapshot(key)
 		Expect(err).ToNot(HaveOccurred())
 		// check versions for resources
-		Expect(snap.GetResources(rsrc.ListenerType).Version).To(Equal(version))
-		Expect(snap.GetResources(rsrc.ClusterType).Version).To(Equal(version))
-		Expect(snap.GetResources(rsrc.RouteType).Version).To(Equal(version))
+		Expect(snap.GetResources(resource.ListenerTypeV3).Version).To(Equal(version))
+		Expect(snap.GetResources(resource.ClusterTypeV3).Version).To(Equal(version))
+		Expect(snap.GetResources(resource.RouteTypeV3).Version).To(Equal(version))
 		// endpoint resource was not set in snapshot
-		Expect(snap.GetResources(rsrc.EndpointType).Version).To(Equal(""))
+		Expect(snap.GetResources(resource.EndpointTypeV3).Version).To(Equal(""))
 
 		newName := "test2"
 		snapshot2 := &TestSnapshot{
@@ -136,11 +133,11 @@ var _ = Describe("Control Plane Cache", func() {
 		snap2, err := c.GetSnapshot(key)
 		Expect(err).ToNot(HaveOccurred())
 		// update to version y
-		Expect(snap2.GetResources(rsrc.EndpointType).Version).To(Equal(version2))
-		Expect(snap2.GetResources(rsrc.ClusterType).Version).To(Equal(version2))
+		Expect(snap2.GetResources(resource.EndpointTypeV3).Version).To(Equal(version2))
+		Expect(snap2.GetResources(resource.ClusterTypeV3).Version).To(Equal(version2))
 		// the cache will reset to empty version for missing resources
-		Expect(snap2.GetResources(rsrc.ListenerType).Version).To(Equal(""))
-		Expect(snap2.GetResources(rsrc.RouteType).Version).To(Equal(""))
+		Expect(snap2.GetResources(resource.ListenerTypeV3).Version).To(Equal(""))
+		Expect(snap2.GetResources(resource.RouteTypeV3).Version).To(Equal(""))
 	})
 
 })

--- a/pkg/api/v1/control-plane/cache/cache_test.go
+++ b/pkg/api/v1/control-plane/cache/cache_test.go
@@ -1,9 +1,12 @@
-package cache
+package cache_test
 
 import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	rsrc "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/solo-io/solo-kit/pkg/api/v1/control-plane/cache"
+	"github.com/solo-io/solo-kit/pkg/api/v1/control-plane/resource"
 )
 
 // TestIDHash uses ID field as the node hash.
@@ -17,11 +20,18 @@ func (TestIDHash) ID(node *envoy_config_core_v3.Node) string {
 	return node.Id
 }
 
+const (
+	clusterName = "test"
+	routeName   = "test-route"
+	version     = "x"
+	version2    = "y"
+)
+
 var _ = Describe("Control Plane Cache", func() {
 
 	It("returns sane values for NewStatusInfo", func() {
 		node := &envoy_config_core_v3.Node{Id: "test"}
-		info := newStatusInfo(node)
+		info := cache.NewStatusInfo(node)
 
 		Expect(info.GetNode()).To(Equal(node))
 
@@ -31,19 +41,106 @@ var _ = Describe("Control Plane Cache", func() {
 	})
 
 	It("returns sane values for GetStatusKeys", func() {
-		cache := NewSnapshotCache(false, TestIDHash{}, nil)
+		c := cache.NewSnapshotCache(false, TestIDHash{}, nil)
 
-		keys := cache.GetStatusKeys()
+		keys := c.GetStatusKeys()
 		Expect(len(keys)).To(Equal(0))
 
-		cache.SetSnapshot("test", nil)
-		cache.CreateWatch(Request{
+		c.SetSnapshot("test", nil)
+		c.CreateWatch(cache.Request{
 			VersionInfo: "",
 			Node: &envoy_config_core_v3.Node{
 				Id: "test",
 			},
 		})
-		keys = cache.GetStatusKeys()
+		keys = c.GetStatusKeys()
 		Expect(keys).To(Equal([]string{"test"}))
 	})
+
+	It("Setting snapshot correctly updates the version", func() {
+		names := map[string][]string{
+			rsrc.EndpointType: {clusterName},
+			rsrc.ClusterType:  nil,
+			rsrc.RouteType:    {routeName},
+			rsrc.ListenerType: nil,
+			rsrc.RuntimeType:  nil,
+		}
+
+		testTypes := []string{
+			rsrc.EndpointType,
+			rsrc.ClusterType,
+			rsrc.RouteType,
+			rsrc.ListenerType,
+			rsrc.RuntimeType,
+		}
+
+		c := cache.NewSnapshotCache(true, TestIDHash{}, nil)
+		key := "test"
+
+		_, err := c.GetSnapshot(key)
+		Expect(err).To(MatchError("no snapshot found for node test"))
+
+		watches := make(map[string]chan cache.Response)
+		for _, typ := range testTypes {
+			watches[typ], _ = c.CreateWatch(cache.Request{
+				TypeUrl:       typ,
+				ResourceNames: names[typ],
+				VersionInfo:   version,
+				Node: &envoy_config_core_v3.Node{
+					Id: "test",
+				},
+			})
+		}
+
+		snapshot := &TestSnapshot{
+			Clusters: cache.NewResources(version, []cache.Resource{
+				resource.NewEnvoyResource(makeCluster(clusterName)),
+			}),
+			Listeners: cache.NewResources(version, []cache.Resource{
+				resource.NewEnvoyResource(makeHTTPListener(routeName)),
+			}),
+			Routes: cache.NewResources(version, []cache.Resource{
+				resource.NewEnvoyResource(makeRoute(routeName, clusterName)),
+			}),
+		}
+
+		err = snapshot.Consistent()
+		Expect(err).ToNot(HaveOccurred())
+		err = c.SetSnapshot(key, snapshot)
+		Expect(err).ToNot(HaveOccurred())
+
+		snap, err := c.GetSnapshot(key)
+		Expect(err).ToNot(HaveOccurred())
+		// check versions for resources
+		Expect(snap.GetResources(rsrc.ListenerType).Version).To(Equal(version))
+		Expect(snap.GetResources(rsrc.ClusterType).Version).To(Equal(version))
+		Expect(snap.GetResources(rsrc.RouteType).Version).To(Equal(version))
+		// endpoint resource was not set in snapshot
+		Expect(snap.GetResources(rsrc.EndpointType).Version).To(Equal(""))
+
+		newName := "test2"
+		snapshot2 := &TestSnapshot{
+			Endpoints: cache.NewResources(version2, []cache.Resource{
+				resource.NewEnvoyResource(makeEndpoint(newName)),
+			}),
+			Clusters: cache.NewResources(version2, []cache.Resource{
+				resource.NewEnvoyResource(makeEDSCluster(newName)),
+			}),
+		}
+
+		err = snapshot2.Consistent()
+		Expect(err).ToNot(HaveOccurred())
+		err = c.SetSnapshot(key, snapshot2)
+		Expect(err).ToNot(HaveOccurred())
+
+		snap2, err := c.GetSnapshot(key)
+		Expect(err).ToNot(HaveOccurred())
+		// update to version y
+		Expect(snap2.GetResources(rsrc.EndpointType).Version).To(Equal(version2))
+		Expect(snap2.GetResources(rsrc.ClusterType).Version).To(Equal(version2))
+		// the cache will reset to empty version for missing resources
+		Expect(snap2.GetResources(rsrc.ListenerType).Version).To(Equal(""))
+		Expect(snap2.GetResources(rsrc.RouteType).Version).To(Equal(""))
+	})
+
 })

--- a/pkg/api/v1/control-plane/cache/simple.go
+++ b/pkg/api/v1/control-plane/cache/simple.go
@@ -139,10 +139,15 @@ func (cache *snapshotCache) SetSnapshot(node string, snapshot Snapshot) error {
 				if cache.log != nil {
 					cache.log.Infof("respond open watch %d%v with new version %q", id, watch.Request.ResourceNames, version)
 				}
-				cache.respond(watch.Request, watch.Response, snapshot.GetResources(watch.Request.TypeUrl).Items, version)
 
-				// discard the watch
-				delete(info.watches, id)
+				resources := snapshot.GetResources(watch.Request.TypeUrl).Items
+				if resources != nil {
+					// snapshot has been initialized and exists
+					cache.respond(watch.Request, watch.Response, resources, version)
+
+					// discard the watch
+					delete(info.watches, id)
+				}
 			}
 		}
 		info.mu.Unlock()
@@ -201,7 +206,7 @@ func (cache *snapshotCache) CreateWatch(request Request) (chan Response, func())
 
 	info, ok := cache.status[nodeID]
 	if !ok {
-		info = newStatusInfo(request.Node)
+		info = NewStatusInfo(request.Node)
 		cache.status[nodeID] = info
 	}
 

--- a/pkg/api/v1/control-plane/cache/simple.go
+++ b/pkg/api/v1/control-plane/cache/simple.go
@@ -141,6 +141,9 @@ func (cache *snapshotCache) SetSnapshot(node string, snapshot Snapshot) error {
 				}
 
 				resources := snapshot.GetResources(watch.Request.TypeUrl).Items
+				// Before sending a response, need to be able to differentiate between a resource in the snapshot that does not exist vs. should be empty
+				// nil resource - not set in the snapshot and should not be updated
+				// empty resource - intended behavior is for the resources to be cleared
 				if resources != nil {
 					// snapshot has been initialized and exists
 					cache.respond(watch.Request, watch.Response, resources, version)

--- a/pkg/api/v1/control-plane/cache/status.go
+++ b/pkg/api/v1/control-plane/cache/status.go
@@ -64,8 +64,8 @@ type ResponseWatch struct {
 	Response chan Response
 }
 
-// newStatusInfo initializes a status info data structure.
-func newStatusInfo(node *envoy_config_core_v3.Node) *statusInfo {
+// NewStatusInfo initializes a status info data structure.
+func NewStatusInfo(node *envoy_config_core_v3.Node) *statusInfo {
 	out := statusInfo{
 		node:    node,
 		watches: make(map[int64]ResponseWatch),


### PR DESCRIPTION
Currently, there is no way to determine if a resource in the snapshot does not exist or should be empty. This means SetSnapshot will send a response to envoy with nil listeners/routes if only the endpoints/clusters are set. 

The gloo envoy snapshot will set the resource to an empty list if the intended behavior is for the resources to be cleared. Otherwise when updating only endpoints it will either use the previous snapshot value or not set the listener/route.

Part of fix for: https://github.com/solo-io/gloo/issues/4345