### PR TITLE
Proto compiler optimizations and metrics

### DIFF
--- a/changelog/v0.18.4/proto-compiler-optimization.yaml
+++ b/changelog/v0.18.4/proto-compiler-optimization.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4559
+    resolvesIssue: false
+    description: Adds memoization to proto compilation to reduce execution time.

--- a/changelog/v0.19.0/proto-compiler-optimization.yaml
+++ b/changelog/v0.19.0/proto-compiler-optimization.yaml
@@ -1,5 +1,5 @@
 changelog:
-  - type: NON_USER_FACING
+  - type: BREAKING_CHANGE
     issueLink: https://github.com/solo-io/gloo/issues/4559
     resolvesIssue: false
     description: Adds memoization to proto compilation to reduce execution time.

--- a/pkg/code-generator/cmd/main.go
+++ b/pkg/code-generator/cmd/main.go
@@ -266,10 +266,10 @@ func (r *Runner) Run() error {
 		return false
 	}
 
-	descriptorCollector := collector.NewCollector(r.Opts.CustomImports, r.CommonImports,
+	descriptorCollector := collector.NewProtoCompiler(r.Opts.CustomImports, r.CommonImports,
 		r.Opts.CustomGoOutArgs, r.Opts.CustomPlugins, r.DescriptorOutDir, compileProto)
 
-	descriptors, err := descriptorCollector.CollectDescriptorsFromRoot(filepath.Join(r.BaseDir, anyvendor.DefaultDepDir), r.Opts.SkipDirs)
+	descriptors, err := descriptorCollector.CompileDescriptorsFromRoot(filepath.Join(r.BaseDir, anyvendor.DefaultDepDir), r.Opts.SkipDirs)
 	if err != nil {
 		return err
 	}

--- a/pkg/code-generator/collector/collector.go
+++ b/pkg/code-generator/collector/collector.go
@@ -1,0 +1,154 @@
+package collector
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/solo-io/solo-kit/pkg/code-generator/metrics"
+
+	"github.com/rotisserie/eris"
+	"github.com/solo-io/go-utils/log"
+	"github.com/solo-io/go-utils/stringutils"
+)
+
+type Collector interface {
+	CollectImportsForFile(root, protoFile string) ([]string, error)
+}
+
+func NewCollector(customImports, commonImports []string) *collector {
+	return &collector{
+		customImports:    customImports,
+		commonImports:    commonImports,
+		importsExtractor: NewSynchronizedImportsExtractor(),
+	}
+}
+
+type collector struct {
+	customImports []string
+	commonImports []string
+
+	// The collector traverses a tree of files, opening and parsing each one.
+	// These are costly operations that are often duplicated (ie fileA and fileB both import fileC)
+	// The importsExtractor allows us to separate *how* to fetch imports from a file
+	// from *when* to fetch imports from a file. This allows us to define a caching layer
+	// in the importsExtractor and the collector doesn't have to be aware of it.
+	importsExtractor ImportsExtractor
+}
+
+func (c *collector) CollectImportsForFile(root, protoFile string) ([]string, error) {
+	return c.synchronizedImportsForProtoFile(root, protoFile, c.customImports)
+}
+
+var protoImportStatementRegex = regexp.MustCompile(`.*import "(.*)";.*`)
+
+func (c *collector) detectImportsForFile(file string) ([]string, error) {
+	metrics.IncrementFrequency("collector-opened-files")
+
+	content, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(content), "\n")
+	var protoImports []string
+	for _, line := range lines {
+		importStatement := protoImportStatementRegex.FindStringSubmatch(line)
+		if len(importStatement) == 0 {
+			continue
+		}
+		if len(importStatement) != 2 {
+			return nil, eris.Errorf("parsing import line error: from %v found %v", line, importStatement)
+		}
+		protoImports = append(protoImports, importStatement[1])
+	}
+	return protoImports, nil
+}
+
+func (c *collector) synchronizedImportsForProtoFile(absoluteRoot, protoFile string, customImports []string) ([]string, error) {
+	// Define how we will extract the imports for the proto file
+	importsFetcher := func(protoFileName string) ([]string, error) {
+		return c.importsForProtoFile(absoluteRoot, protoFileName, customImports)
+	}
+
+	return c.importsExtractor.FetchImportsForFile(protoFile, importsFetcher)
+}
+
+func (c *collector) importsForProtoFile(absoluteRoot, protoFile string, customImports []string) ([]string, error) {
+	importStatements, err := c.detectImportsForFile(protoFile)
+	if err != nil {
+		return nil, err
+	}
+	importsForProto := append([]string{}, c.commonImports...)
+	for _, importedProto := range importStatements {
+		importPath, err := c.findImportRelativeToRoot(absoluteRoot, importedProto, customImports, importsForProto)
+		if err != nil {
+			return nil, err
+		}
+		dependency := filepath.Join(importPath, importedProto)
+		dependencyImports, err := c.synchronizedImportsForProtoFile(absoluteRoot, dependency, customImports)
+		if err != nil {
+			return nil, eris.Wrapf(err, "getting imports for dependency")
+		}
+		importsForProto = append(importsForProto, strings.TrimSuffix(importPath, "/"))
+		importsForProto = append(importsForProto, dependencyImports...)
+	}
+	return stringutils.Unique(importsForProto), nil
+}
+
+func (c *collector) findImportRelativeToRoot(absoluteRoot, importedProtoFile string, customImports, existingImports []string) (string, error) {
+	// if the file is already imported, point to that import
+	for _, importPath := range existingImports {
+		if _, err := os.Stat(filepath.Join(importPath, importedProtoFile)); err == nil {
+			return importPath, nil
+		}
+	}
+	rootsToTry := []string{absoluteRoot}
+
+	for _, customImport := range customImports {
+		absoluteCustomImport, err := filepath.Abs(customImport)
+		if err != nil {
+			return "", err
+		}
+		// Try the more specific custom imports first, rather than trying all of vendor
+		rootsToTry = append([]string{absoluteCustomImport}, rootsToTry...)
+	}
+
+	// Sort by length, so longer (more specific paths are attempted first)
+	sort.Slice(rootsToTry, func(i, j int) bool {
+		elementsJ := strings.Split(rootsToTry[j], string(os.PathSeparator))
+		elementsI := strings.Split(rootsToTry[i], string(os.PathSeparator))
+		return len(elementsI) > len(elementsJ)
+	})
+
+	var possibleImportPaths []string
+	for _, root := range rootsToTry {
+		if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if strings.HasSuffix(path, importedProtoFile) {
+				importPath := strings.TrimSuffix(path, importedProtoFile)
+				possibleImportPaths = append(possibleImportPaths, importPath)
+
+			}
+			return nil
+		}); err != nil {
+			return "", err
+		}
+		// if found break
+		if len(possibleImportPaths) > 0 {
+			break
+		}
+	}
+	if len(possibleImportPaths) == 0 {
+		return "", eris.Errorf("found no possible import paths in root directory %v for import %v",
+			absoluteRoot, importedProtoFile)
+	}
+	if len(possibleImportPaths) != 1 {
+		log.Debugf("found more than one possible import path in root directory for "+
+			"import %v: %v",
+			importedProtoFile, possibleImportPaths)
+	}
+	return possibleImportPaths[0], nil
+
+}

--- a/pkg/code-generator/collector/compiler.go
+++ b/pkg/code-generator/collector/compiler.go
@@ -8,6 +8,9 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
+
+	"github.com/solo-io/solo-kit/pkg/code-generator/metrics"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
@@ -48,6 +51,8 @@ type protoCompiler struct {
 }
 
 func (c *protoCompiler) CompileDescriptorsFromRoot(root string, skipDirs []string) ([]*model.DescriptorWithPath, error) {
+	defer metrics.MeasureElapsed("proto-compiler", time.Now())
+
 	var descriptors []*model.DescriptorWithPath
 	var mutex sync.Mutex
 	addDescriptor := func(f model.DescriptorWithPath) {

--- a/pkg/code-generator/collector/compiler.go
+++ b/pkg/code-generator/collector/compiler.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -215,10 +216,12 @@ var defaultGoArgs = []string{
 
 func (c *protoCompiler) writeDescriptors(protoFile, toFile string, imports []string, compileProtos bool) error {
 	cmd := exec.Command("protoc")
-	for i := range imports {
-		imports[i] = "-I" + imports[i]
+
+	var cmdImports []string
+	for _, i := range imports {
+		cmdImports = append(cmdImports, fmt.Sprintf("-I%s", i))
 	}
-	cmd.Args = append(cmd.Args, imports...)
+	cmd.Args = append(cmd.Args, cmdImports...)
 	goArgs := append(defaultGoArgs, c.customGoArgs...)
 
 	if compileProtos {

--- a/pkg/code-generator/collector/extractor.go
+++ b/pkg/code-generator/collector/extractor.go
@@ -1,0 +1,140 @@
+package collector
+
+import (
+	"sync"
+	"time"
+
+	"github.com/rotisserie/eris"
+)
+
+type ImportsFetcher func(file string) ([]string, error)
+
+type ImportsExtractor interface {
+	FetchImportsForFile(protoFile string, importsFetcher ImportsFetcher) ([]string, error)
+}
+
+// thread-safe
+// The synchronizedImportsExtractor provides synchronized access to imports for a given proto file.
+// It provides 2 useful features for tree traversal:
+//	1. Imports for each file are cached, ensuring that if we attempt to access that file
+//		during traversal again, we do not need to duplicate work.
+//	2. If imports for a file are unknown, and simultaneous go routines attempt to load
+//		the imports, only 1 will execute and the other will block, waiting for the result.
+//		This reduces the number of times we open and parse files.
+type synchronizedImportsExtractor struct {
+	// cachedImports contains a map of fileImports, each indexed by their file name
+	cachedImports sync.Map
+
+	// protect access to activeRequests
+	activeRequestsMu sync.RWMutex
+	activeRequests   map[string]*importsFetchRequest
+}
+
+type fileImports struct {
+	imports []string
+	err     error
+}
+
+func NewSynchronizedImportsExtractor() ImportsExtractor {
+	return &synchronizedImportsExtractor{
+		activeRequests: map[string]*importsFetchRequest{},
+	}
+}
+
+var (
+	FetchImportsTimeout = func(filename string) error {
+		return eris.Errorf("Timed out while fetching imports for proto file: [%s]", filename)
+	}
+)
+
+func (i *synchronizedImportsExtractor) FetchImportsForFile(protoFile string, importsFetcher ImportsFetcher) ([]string, error) {
+	// Attempt to load the imports from the cache
+	cachedImports, ok := i.cachedImports.Load(protoFile)
+	if ok {
+		typedCachedImports := cachedImports.(*fileImports)
+		return typedCachedImports.imports, typedCachedImports.err
+	}
+
+	i.activeRequestsMu.Lock()
+
+	// If there's not a current active request for this file, create one.
+	activeRequest := i.activeRequests[protoFile]
+	if activeRequest == nil {
+		activeRequest = newImportsFetchRequest()
+		i.activeRequests[protoFile] = activeRequest
+
+		// This goroutine has exclusive ownership over the current request.
+		// It releases the resource by nil'ing the importRequest field
+		// once the goroutine is done.
+		go func() {
+			// fetch the imports
+			imports, err := importsFetcher(protoFile)
+
+			// update the cache
+			i.cachedImports.Store(protoFile, &fileImports{imports: imports, err: err})
+
+			// Signal to waiting goroutines
+			activeRequest.done(imports, err)
+
+			// Free active request so a different request can run.
+			i.activeRequestsMu.Lock()
+			defer i.activeRequestsMu.Unlock()
+			delete(i.activeRequests, protoFile)
+		}()
+	}
+
+	inflightRequest := i.activeRequests[protoFile]
+	i.activeRequestsMu.Unlock()
+
+	select {
+	case <-time.After(5 * time.Second):
+		// We should never reach this. This can only occur if we deadlock on file imports
+		// which only happens with cyclic dependencies
+		// Perhaps a safer alternative to erroring is just to execute the importsFetcher:
+		// 	return importsFetcher(protoFile)
+		return nil, FetchImportsTimeout(protoFile)
+	case <-inflightRequest.wait():
+		// Wait for the existing request to complete, then return
+		return inflightRequest.result()
+	}
+}
+
+// importsFetchRequest is used to wait on some in-flight request from multiple goroutines.
+// Derived from: https://github.com/coreos/go-oidc/blob/08563f61dbb316f8ef85b784d01da503f2480690/oidc/jwks.go#L53
+type importsFetchRequest struct {
+	doneCh  chan struct{}
+	imports []string
+	err     error
+}
+
+func newImportsFetchRequest() *importsFetchRequest {
+	return &importsFetchRequest{doneCh: make(chan struct{})}
+}
+
+// wait returns a channel that multiple goroutines can receive on. Once it returns
+// a value, the inflight request is done and result() can be inspected.
+func (i *importsFetchRequest) wait() <-chan struct{} {
+	return i.doneCh
+}
+
+// done can only be called by a single goroutine. It records the result of the
+// inflight request and signals other goroutines that the result is safe to
+// inspect.
+func (i *importsFetchRequest) done(imports []string, err error) {
+	i.imports = imports
+	i.err = err
+	close(i.doneCh)
+}
+
+// result cannot be called until the wait() channel has returned a value.
+func (i *importsFetchRequest) result() ([]string, error) {
+	return i.imports, i.err
+}
+
+// This is the old implementation, that does not include caching or locking
+type primitiveImportsExtractor struct {
+}
+
+func (p *primitiveImportsExtractor) FetchImportsForFile(protoFile string, importsFetcher ImportsFetcher) ([]string, error) {
+	return importsFetcher(protoFile)
+}

--- a/pkg/code-generator/metrics/metrics.go
+++ b/pkg/code-generator/metrics/metrics.go
@@ -1,0 +1,80 @@
+package metrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+var (
+	aggregator *metricAggregator
+)
+
+func NewAggregator() {
+	aggregator = newMetricAggregator()
+}
+
+func MeasureElapsed(key string, startTime time.Time) {
+	aggregator.setDurationMetric(keyWithGlobalNamespace(key), time.Since(startTime).String())
+}
+
+func IncrementFrequency(key string) {
+	aggregator.incrementFrequencyMetric(keyWithGlobalNamespace(key))
+}
+
+func keyWithGlobalNamespace(key string) string {
+	// ensure global keys are grouped together, and listed first in the map
+	return fmt.Sprintf("%s/%s", "@code-generator", key)
+}
+
+func Flush(writer io.Writer) error {
+	byt, err := aggregator.getMetrics()
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(byt)
+	return err
+}
+
+// This is a primitive implementation for compiling performance measurements of code-gen
+// If we need it, we could substitute this with something more heavy handed like:
+//	https://github.com/armon/go-metrics
+type metricAggregator struct {
+	metricsMu sync.Mutex
+
+	DurationMetrics  map[string]string `json:"duration"`
+	FrequencyMetrics map[string]int64  `json:"frequency"`
+}
+
+func newMetricAggregator() *metricAggregator {
+	return &metricAggregator{
+		DurationMetrics:  map[string]string{},
+		FrequencyMetrics: map[string]int64{},
+	}
+}
+
+func (m *metricAggregator) setDurationMetric(key, value string) {
+	m.metricsMu.Lock()
+	defer m.metricsMu.Unlock()
+	m.DurationMetrics[key] = value
+}
+
+func (m *metricAggregator) incrementFrequencyMetric(key string) {
+	m.metricsMu.Lock()
+	defer m.metricsMu.Unlock()
+	v, ok := m.FrequencyMetrics[key]
+	if ok {
+		m.FrequencyMetrics[key] = v + 1
+	} else {
+		m.FrequencyMetrics[key] = 1
+	}
+}
+
+func (m *metricAggregator) getMetrics() ([]byte, error) {
+	m.metricsMu.Lock()
+	defer m.metricsMu.Unlock()
+
+	return json.MarshalIndent(m, "", "    ")
+}


### PR DESCRIPTION
# Description

- When compiling protos, use memoization to avoid parsing the same file multiple times
- Add some basic metrics around duration and frequency of execution, to better understand where bottlenecks are.

# Context

Some recent work in solo-kit (https://github.com/solo-io/solo-kit/pull/415) illustrated that proto compilation (which requires walking a tree of files, accumulating all the imports) takes a long time. This is due to the fact that for each imported file, we parse that file, read the imports and continue. This means, that if we fileA and fileB both import fileC, we will parse fileC twice. The amount of duplicated work grows as the dependency graph gets more complex. 

I added some simple metrics to understand the compilation bottleneck, and ran codegen for gloo. Below are the measurements for our existing implementation of proto compilation compared with the measurements from this change.

### Before (no caching)

```
{
    "duration": {
        "@code-generator/proto-compiler": "23.12s"
    },
    "frequency": {
        "@code-generator/collector-opened-files": 16116
    }
}
```

### After (with caching)

```
{
    "duration": {
        "@code-generator/proto-compiler": "8.41s"
    },
    "frequency": {
        "@code-generator/collector-opened-files": 135
    }
}
```

# Testing
- [x] Successfully executed code-gen in gloo, using this version