### PR TITLE
Go package compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ root level `generate.go` file.
 
 ## upgrading to v0.12.0 (solo-kit with go.mod)
 
-As of go 1.11, go began introducing support for go modules, it's dependency management system.
+As of go 1.11, go began introducing support for go modules, its dependency management system.
 As of solo-kit 0.12.0 we will officially support running solo-kit with go.mod outside of the GOPATH.
 
 This change has been a lot time coming, but it also means a few changes to solo-kit.

--- a/api/external/metrics.proto
+++ b/api/external/metrics.proto
@@ -21,7 +21,7 @@ import "extproto/ext.proto";
 option (extproto.hash_all) = true;
 option (extproto.equal_all) = true;
 
-option go_package = "metricsproto";
+option go_package = "./metricsproto";
 
 message LabelPair {
   optional string name  = 1;

--- a/api/external/metrics.proto
+++ b/api/external/metrics.proto
@@ -21,7 +21,7 @@ import "extproto/ext.proto";
 option (extproto.hash_all) = true;
 option (extproto.equal_all) = true;
 
-option go_package = "./metricsproto";
+option go_package = "github.com/prometheus/client_model/go;io_prometheus_client";
 
 message LabelPair {
   optional string name  = 1;

--- a/api/external/metrics.proto
+++ b/api/external/metrics.proto
@@ -16,12 +16,13 @@ syntax = "proto2";
 package io.prometheus.client;
 option java_package = "io.prometheus.client";
 
-
 import "extproto/ext.proto";
 option (extproto.hash_all) = true;
 option (extproto.equal_all) = true;
 
 option go_package = "github.com/prometheus/client_model/go;io_prometheus_client";
+
+import "google/protobuf/timestamp.proto";
 
 message LabelPair {
   optional string name  = 1;
@@ -41,7 +42,8 @@ message Gauge {
 }
 
 message Counter {
-  optional double value = 1;
+  optional double   value    = 1;
+  optional Exemplar exemplar = 2;
 }
 
 message Quantile {
@@ -66,8 +68,15 @@ message Histogram {
 }
 
 message Bucket {
-  optional uint64 cumulative_count = 1; // Cumulative in increasing order.
-  optional double upper_bound = 2;      // Inclusive.
+  optional uint64   cumulative_count = 1; // Cumulative in increasing order.
+  optional double   upper_bound      = 2; // Inclusive.
+  optional Exemplar exemplar         = 3;
+}
+
+message Exemplar {
+  repeated LabelPair                 label     = 1;
+  optional double                    value     = 2;
+  optional google.protobuf.Timestamp timestamp = 3; // OpenMetrics-style.
 }
 
 message Metric {

--- a/api/external/metrics.proto
+++ b/api/external/metrics.proto
@@ -16,13 +16,12 @@ syntax = "proto2";
 package io.prometheus.client;
 option java_package = "io.prometheus.client";
 
+
 import "extproto/ext.proto";
 option (extproto.hash_all) = true;
 option (extproto.equal_all) = true;
 
 option go_package = "github.com/prometheus/client_model/go;io_prometheus_client";
-
-import "google/protobuf/timestamp.proto";
 
 message LabelPair {
   optional string name  = 1;
@@ -42,8 +41,7 @@ message Gauge {
 }
 
 message Counter {
-  optional double   value    = 1;
-  optional Exemplar exemplar = 2;
+  optional double value = 1;
 }
 
 message Quantile {
@@ -68,15 +66,8 @@ message Histogram {
 }
 
 message Bucket {
-  optional uint64   cumulative_count = 1; // Cumulative in increasing order.
-  optional double   upper_bound      = 2; // Inclusive.
-  optional Exemplar exemplar         = 3;
-}
-
-message Exemplar {
-  repeated LabelPair                 label     = 1;
-  optional double                    value     = 2;
-  optional google.protobuf.Timestamp timestamp = 3; // OpenMetrics-style.
+  optional uint64 cumulative_count = 1; // Cumulative in increasing order.
+  optional double upper_bound = 2;      // Inclusive.
 }
 
 message Metric {

--- a/api/external/trace.proto
+++ b/api/external/trace.proto
@@ -28,7 +28,7 @@ option java_multiple_files = true;
 option java_package = "io.opencensus.proto.trace";
 option java_outer_classname = "TraceProto";
 
-option go_package = "traceproto";
+option go_package = "./traceproto";
 
 // A span represents a single operation within a trace. Spans can be
 // nested to form a trace tree. Often, a trace contains a root span

--- a/api/external/trace.proto
+++ b/api/external/trace.proto
@@ -28,7 +28,7 @@ option java_multiple_files = true;
 option java_package = "io.opencensus.proto.trace";
 option java_outer_classname = "TraceProto";
 
-option go_package = "./traceproto";
+option go_package = "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1";
 
 // A span represents a single operation within a trace. Spans can be
 // nested to form a trace tree. Often, a trace contains a root span

--- a/changelog/v0.21.0/gopackage-compliance.yaml
+++ b/changelog/v0.21.0/gopackage-compliance.yaml
@@ -1,4 +1,4 @@
 changelog:
-  - type: FIX
+  - type: BREAKING_CHANGE
     description: Update `go_package` field of external protos to comply with latest `protoc-gen-go` requirements.
     issueLink: https://github.com/solo-io/solo-kit/issues/427

--- a/changelog/v0.21.0/gopackage-compliance.yaml
+++ b/changelog/v0.21.0/gopackage-compliance.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: FIX
+    description: Update `go_package` field of external protos to comply with latest `protoc-gen-go` requirements.

--- a/changelog/v0.21.0/gopackage-compliance.yaml
+++ b/changelog/v0.21.0/gopackage-compliance.yaml
@@ -1,3 +1,4 @@
 changelog:
   - type: FIX
     description: Update `go_package` field of external protos to comply with latest `protoc-gen-go` requirements.
+    issueLink: https://github.com/solo-io/solo-kit/issues/427

--- a/changelog/v0.21.0/gopath-compliance.yaml
+++ b/changelog/v0.21.0/gopath-compliance.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: FIX
+    description: Update `go_path` field of external protos to comply with latest `protoc-gen-go` requirements..

--- a/changelog/v0.21.0/gopath-compliance.yaml
+++ b/changelog/v0.21.0/gopath-compliance.yaml
@@ -1,3 +1,0 @@
-changelog:
-  - type: FIX
-    description: Update `go_path` field of external protos to comply with latest `protoc-gen-go` requirements..


### PR DESCRIPTION
New versions of `github.com/golang/protobuf` require that the `go_package` in proto files has at least one '/'. 

This PR updates the offending protos from what is, as far as I can tell, their current versions:
https://github.com/census-instrumentation/opencensus-proto/blob/master/src/opencensus/proto/trace/v1/trace.proto
https://github.com/prometheus/client_model/blob/master/metrics.proto

In theory, these path updates are breaking changes (hence the 0.21.0 version). In practice, it does not seem that any go code currently imports them (that is, searching the solo-io org on github did not produce any hits for the go package name in go code).
BOT NOTES: 
resolves https://github.com/solo-io/solo-kit/issues/427