### PR TITLE
Support custom Vault secret prefix

### DIFF
--- a/changelog/v0.24.3/support-custom-vault-secret-prefix.yaml
+++ b/changelog/v0.24.3/support-custom-vault-secret-prefix.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo/issues/6184
+    resolvesIssue: false
+    description: Allow configuration of the "secret/" root path for Hashicorp's Vault integration.

--- a/changelog/v0.24.3/support-custom-vault-secret-prefix.yaml
+++ b/changelog/v0.24.3/support-custom-vault-secret-prefix.yaml
@@ -1,5 +1,0 @@
-changelog:
-  - type: NEW_FEATURE
-    issueLink: https://github.com/solo-io/gloo/issues/6184
-    resolvesIssue: false
-    description: Allow configuration of the "secret/" root path for Hashicorp's Vault integration.

--- a/changelog/v0.26.0/support-custom-vault-secret-prefix.yaml
+++ b/changelog/v0.26.0/support-custom-vault-secret-prefix.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: BREAKING_CHANGE
+    issueLink: https://github.com/solo-io/gloo/issues/6184
+    resolvesIssue: false
+    description: Expose `pathPrefix` to allow configuration of the root (secrets engine) path for Vault integration.

--- a/pkg/api/v1/clients/factory/resource_client_factory.go
+++ b/pkg/api/v1/clients/factory/resource_client_factory.go
@@ -147,7 +147,7 @@ func newResourceClient(ctx context.Context, factory ResourceClientFactory, param
 		if !ok {
 			return nil, errors.Errorf("the vault storage client can only be used for resources which implement the resources.VersionedResource interface resources, received type %v", resources.Kind(resourceType))
 		}
-		return vault.NewResourceClient(opts.Vault, opts.RootKey, opts.PathPrefix, versionedResource), nil
+		return vault.NewResourceClient(opts.Vault, opts.PathPrefix, opts.RootKey, versionedResource), nil
 	}
 	panic("unsupported type " + reflect.TypeOf(factory).Name())
 }
@@ -238,8 +238,8 @@ func (f *KubeSecretClientFactory) NewResourceClient(ctx context.Context, params 
 
 type VaultSecretClientFactory struct {
 	Vault      *vaultapi.Client
-	RootKey    string
 	PathPrefix string
+	RootKey    string
 }
 
 func (f *VaultSecretClientFactory) NewResourceClient(ctx context.Context, params NewResourceClientParams) (clients.ResourceClient, error) {

--- a/pkg/api/v1/clients/factory/resource_client_factory.go
+++ b/pkg/api/v1/clients/factory/resource_client_factory.go
@@ -147,7 +147,7 @@ func newResourceClient(ctx context.Context, factory ResourceClientFactory, param
 		if !ok {
 			return nil, errors.Errorf("the vault storage client can only be used for resources which implement the resources.VersionedResource interface resources, received type %v", resources.Kind(resourceType))
 		}
-		return vault.NewResourceClient(opts.Vault, opts.RootKey, versionedResource), nil
+		return vault.NewResourceClient(opts.Vault, opts.RootKey, opts.PathPrefix, versionedResource), nil
 	}
 	panic("unsupported type " + reflect.TypeOf(factory).Name())
 }
@@ -237,8 +237,9 @@ func (f *KubeSecretClientFactory) NewResourceClient(ctx context.Context, params 
 }
 
 type VaultSecretClientFactory struct {
-	Vault   *vaultapi.Client
-	RootKey string
+	Vault      *vaultapi.Client
+	RootKey    string
+	PathPrefix string
 }
 
 func (f *VaultSecretClientFactory) NewResourceClient(ctx context.Context, params NewResourceClientParams) (clients.ResourceClient, error) {

--- a/pkg/api/v1/clients/vault/resource_client.go
+++ b/pkg/api/v1/clients/vault/resource_client.go
@@ -312,7 +312,7 @@ func (rc *ResourceClient) resourceDirectory(namespace, directoryType string) str
 	}
 
 	return strings.Join([]string{
-		"secreto",
+		rc.pathPrefix,
 		directoryType,
 		rc.root,
 		rc.resourceType.GroupVersionKind().Group,

--- a/pkg/api/v1/clients/vault/resource_client.go
+++ b/pkg/api/v1/clients/vault/resource_client.go
@@ -70,13 +70,15 @@ func (rc *ResourceClient) toVaultSecret(resource resources.Resource) (map[string
 type ResourceClient struct {
 	vault        *api.Client
 	root         string
+	pathPrefix   string
 	resourceType resources.VersionedResource
 }
 
-func NewResourceClient(client *api.Client, rootKey string, resourceType resources.VersionedResource) *ResourceClient {
+func NewResourceClient(client *api.Client, rootKey string, pathPrefix string, resourceType resources.VersionedResource) *ResourceClient {
 	return &ResourceClient{
 		vault:        client,
 		root:         rootKey,
+		pathPrefix:   pathPrefix,
 		resourceType: resourceType,
 	}
 }
@@ -305,8 +307,12 @@ const (
 )
 
 func (rc *ResourceClient) resourceDirectory(namespace, directoryType string) string {
+	if rc.pathPrefix == "" {
+		rc.pathPrefix = "secret"
+	}
+
 	return strings.Join([]string{
-		"secret",
+		"secreto",
 		directoryType,
 		rc.root,
 		rc.resourceType.GroupVersionKind().Group,

--- a/pkg/api/v1/clients/vault/resource_client.go
+++ b/pkg/api/v1/clients/vault/resource_client.go
@@ -68,17 +68,26 @@ func (rc *ResourceClient) toVaultSecret(resource resources.Resource) (map[string
 }
 
 type ResourceClient struct {
-	vault        *api.Client
-	root         string
+	vault *api.Client
+
+	// Vault's path where resources are located.
+	root string
+
+	// Tells Vault which secrets engine it should route traffic to. Defaults to "secret".
+	// https://learn.hashicorp.com/tutorials/vault/getting-started-secrets-engines
 	pathPrefix   string
 	resourceType resources.VersionedResource
 }
 
-func NewResourceClient(client *api.Client, rootKey string, pathPrefix string, resourceType resources.VersionedResource) *ResourceClient {
+func NewResourceClient(client *api.Client, pathPrefix string, rootKey string, resourceType resources.VersionedResource) *ResourceClient {
+	if pathPrefix == "" {
+		pathPrefix = "secret"
+	}
+
 	return &ResourceClient{
 		vault:        client,
-		root:         rootKey,
 		pathPrefix:   pathPrefix,
+		root:         rootKey,
 		resourceType: resourceType,
 	}
 }
@@ -307,10 +316,6 @@ const (
 )
 
 func (rc *ResourceClient) resourceDirectory(namespace, directoryType string) string {
-	if rc.pathPrefix == "" {
-		rc.pathPrefix = "secret"
-	}
-
 	return strings.Join([]string{
 		rc.pathPrefix,
 		directoryType,

--- a/pkg/api/v1/clients/vault/resource_client_test.go
+++ b/pkg/api/v1/clients/vault/resource_client_test.go
@@ -3,8 +3,9 @@ package vault_test
 import (
 	"context"
 	"fmt"
-	"github.com/solo-io/solo-kit/test/setup"
 	"time"
+
+	"github.com/solo-io/solo-kit/test/setup"
 
 	"github.com/hashicorp/vault/api"
 	. "github.com/onsi/ginkgo"

--- a/pkg/api/v1/clients/vault/resource_client_test.go
+++ b/pkg/api/v1/clients/vault/resource_client_test.go
@@ -3,6 +3,7 @@ package vault_test
 import (
 	"context"
 	"fmt"
+	"github.com/solo-io/solo-kit/test/setup"
 	"time"
 
 	"github.com/hashicorp/vault/api"
@@ -17,11 +18,13 @@ import (
 
 var _ = Describe("Base", func() {
 	var (
-		vault   *api.Client
-		rootKey string
-		secrets clients.ResourceClient
+		vault      *api.Client
+		rootKey    string
+		pathPrefix string
+		secrets    clients.ResourceClient
 	)
 	BeforeEach(func() {
+		pathPrefix = setup.DefaultTestPathPrefix
 		rootKey = "test-prefix"
 		cfg := api.DefaultConfig()
 		cfg.Address = fmt.Sprintf("http://127.0.0.1:%v", vaultInstance.Port)
@@ -30,7 +33,7 @@ var _ = Describe("Base", func() {
 		c.SetToken(vaultInstance.Token())
 		Expect(err).NotTo(HaveOccurred())
 		vault = c
-		secrets = NewResourceClient(vault, rootKey, &v1.MockResource{})
+		secrets = NewResourceClient(vault, rootKey, pathPrefix, &v1.MockResource{})
 	})
 	AfterEach(func() {
 		vault.Logical().Delete(rootKey)

--- a/pkg/api/v1/clients/vault/resource_client_test.go
+++ b/pkg/api/v1/clients/vault/resource_client_test.go
@@ -19,8 +19,8 @@ import (
 var _ = Describe("Base", func() {
 	var (
 		vault      *api.Client
-		rootKey    string
 		pathPrefix string
+		rootKey    string
 		secrets    clients.ResourceClient
 	)
 	BeforeEach(func() {
@@ -33,7 +33,7 @@ var _ = Describe("Base", func() {
 		c.SetToken(vaultInstance.Token())
 		Expect(err).NotTo(HaveOccurred())
 		vault = c
-		secrets = NewResourceClient(vault, rootKey, pathPrefix, &v1.MockResource{})
+		secrets = NewResourceClient(vault, pathPrefix, rootKey, &v1.MockResource{})
 	})
 	AfterEach(func() {
 		vault.Logical().Delete(rootKey)

--- a/pkg/api/v1/clients/vault/vault_suite_test.go
+++ b/pkg/api/v1/clients/vault/vault_suite_test.go
@@ -28,7 +28,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	vaultFactory, err = setup.NewVaultFactory()
+	vaultFactory, err = setup.NewVaultFactory(&setup.VaultFactoryConfig{PathPrefix: setup.DefaultTestPathPrefix})
 	Expect(err).NotTo(HaveOccurred())
 	vaultInstance, err = vaultFactory.NewVaultInstance()
 	Expect(err).NotTo(HaveOccurred())

--- a/test/setup/vault.go
+++ b/test/setup/vault.go
@@ -165,16 +165,17 @@ func (i *VaultInstance) RunWithPort() error {
 	}
 
 	i.token = strings.TrimPrefix(tokenSlice[0], "Root Token: ")
-	// secret engine paths get defaulted to "secret/"
-	if i.pathprefix == "" {
-		i.pathprefix = "secret"
+	// don't setup -path if none provided for paths. fixes issues with reusing paths in tests.
+	pathPrefixCfg := ""
+	if i.pathprefix != "" {
+		pathPrefixCfg = fmt.Sprintf("-path=%s", i.pathprefix)
 	}
 	enableCmd := exec.Command(i.vaultpath,
 		"secrets",
 		"enable",
 		fmt.Sprintf("-address=http://127.0.0.1:%v", i.Port),
 		"-version=2",
-		fmt.Sprintf("-path=%s", i.pathprefix),
+		pathPrefixCfg,
 		"kv")
 	enableCmd.Env = append(enableCmd.Env, "VAULT_TOKEN="+i.token)
 

--- a/test/setup/vault.go
+++ b/test/setup/vault.go
@@ -180,7 +180,6 @@ func (i *VaultInstance) RunWithPort() error {
 		// append the -path argument before final cmd.
 		enableCmd.Args = append(args[:len(args)-1], pathPrefixCfg, args[len(args)-1])
 	}
-	fmt.Printf(">>> %v\n", enableCmd.Args)
 
 	enableCmd.Env = append(enableCmd.Env, "VAULT_TOKEN="+i.token)
 

--- a/test/setup/vault.go
+++ b/test/setup/vault.go
@@ -49,9 +49,6 @@ func NewVaultFactory(config *VaultFactoryConfig) (*VaultFactory, error) {
 
 	port := AllocateParallelPort(8200)
 
-	//if config.PathPrefix == "" {
-	//	config.PathPrefix = "secret"
-	//}
 	if vaultpath != "" {
 		return &VaultFactory{
 			vaultpath:  vaultpath,
@@ -90,9 +87,10 @@ docker rm -f $CID
 	}
 
 	return &VaultFactory{
-		vaultpath: filepath.Join(tmpdir, "vault"),
-		tmpdir:    tmpdir,
-		Port:      port,
+		vaultpath:  filepath.Join(tmpdir, "vault"),
+		pathprefix: config.PathPrefix,
+		tmpdir:     tmpdir,
+		Port:       port,
 	}, nil
 }
 

--- a/test/tests/typed/typed_rc_tester.go
+++ b/test/tests/typed/typed_rc_tester.go
@@ -293,7 +293,7 @@ func (rct *VaultRcTester) Skip() bool {
 
 func (rct *VaultRcTester) Setup(_ context.Context, namespace string) factory.ResourceClientFactory {
 	var err error
-	rct.vaultFactory, err = setup.NewVaultFactory()
+	rct.vaultFactory, err = setup.NewVaultFactory(&setup.VaultFactoryConfig{})
 	Expect(err).NotTo(HaveOccurred())
 	rct.vaultInstance, err = rct.vaultFactory.NewVaultInstance()
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Updates
- Add `PathPrefix` `VaultSecretClientFactory` & clientResource.
- Update `resourceDirectory` to use new pathPrefix (or default to "secret/"), instead of hard-coding to `secret`.
- Create `DefaultTestPathPrefix` const for tests to use
- Add path prefix to tests + update `vault secrets` test setup command to use the option `-path=<pathPrefix>`.