### PR TITLE
Consul consistency mode + query options configuration

### DIFF
--- a/changelog/v0.27.0/support-consul-consistency-query-options.yaml
+++ b/changelog/v0.27.0/support-consul-consistency-query-options.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: BREAKING_CHANGE
+    issueLink: https://github.com/solo-io/gloo/issues/6185
+    resolvesIssue: false
+    description: |
+      Expose `queryOptions` to allow configuration for Read/Watch queries.
+      This allows for Consul options, such as stale reads, to be configured through gloo.

--- a/pkg/api/v1/clients/consul/resource_client.go
+++ b/pkg/api/v1/clients/consul/resource_client.go
@@ -22,11 +22,11 @@ type ResourceClient struct {
 	resourceType resources.VersionedResource
 }
 
-func NewResourceClient(client *api.Client, rootKey string, query api.QueryOptions, resourceType resources.VersionedResource) *ResourceClient {
+func NewResourceClient(client *api.Client, rootKey string, queryOptions api.QueryOptions, resourceType resources.VersionedResource) *ResourceClient {
 	return &ResourceClient{
 		consul:       client,
 		root:         rootKey,
-		queryOptions: query,
+		queryOptions: queryOptions,
 		resourceType: resourceType,
 	}
 }

--- a/pkg/api/v1/clients/consul/resource_client.go
+++ b/pkg/api/v1/clients/consul/resource_client.go
@@ -18,11 +18,11 @@ import (
 type ResourceClient struct {
 	consul       *api.Client
 	root         string
-	queryOptions api.QueryOptions
+	queryOptions *api.QueryOptions
 	resourceType resources.VersionedResource
 }
 
-func NewResourceClient(client *api.Client, rootKey string, queryOptions api.QueryOptions, resourceType resources.VersionedResource) *ResourceClient {
+func NewResourceClient(client *api.Client, rootKey string, queryOptions *api.QueryOptions, resourceType resources.VersionedResource) *ResourceClient {
 	return &ResourceClient{
 		consul:       client,
 		root:         rootKey,
@@ -52,7 +52,7 @@ func (rc *ResourceClient) Read(namespace, name string, opts clients.ReadOpts) (r
 	opts = opts.WithDefaults()
 	key := rc.resourceKey(namespace, name)
 
-	kvPair, _, err := rc.consul.KV().Get(key, &rc.queryOptions)
+	kvPair, _, err := rc.consul.KV().Get(key, rc.queryOptions)
 	if err != nil {
 		return nil, errors.Wrapf(err, "performing consul KV get")
 	}
@@ -144,7 +144,7 @@ func (rc *ResourceClient) List(namespace string, opts clients.ListOpts) (resourc
 	opts = opts.WithDefaults()
 
 	resourceDir := rc.resourceDir(namespace)
-	kvPairs, _, err := rc.consul.KV().List(resourceDir, &rc.queryOptions)
+	kvPairs, _, err := rc.consul.KV().List(resourceDir, rc.queryOptions)
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading namespace root")
 	}

--- a/pkg/api/v1/clients/consul/resource_client_test.go
+++ b/pkg/api/v1/clients/consul/resource_client_test.go
@@ -17,9 +17,10 @@ import (
 
 var _ = Describe("Base", func() {
 	var (
-		consul  *api.Client
-		client  *ResourceClient
-		rootKey string
+		consul       *api.Client
+		client       *ResourceClient
+		queryOptions *api.QueryOptions
+		rootKey      string
 	)
 	BeforeEach(func() {
 		rootKey = "my-root-key"
@@ -31,7 +32,7 @@ var _ = Describe("Base", func() {
 		Expect(err).NotTo(HaveOccurred())
 		consul = c
 
-		queryOptions := api.QueryOptions{AllowStale: false, RequireConsistent: true}
+		queryOptions = &api.QueryOptions{AllowStale: false, RequireConsistent: true}
 		client = NewResourceClient(consul, rootKey, queryOptions, &v1.MockResource{})
 	})
 	AfterEach(func() {

--- a/pkg/api/v1/clients/consul/resource_client_test.go
+++ b/pkg/api/v1/clients/consul/resource_client_test.go
@@ -30,7 +30,9 @@ var _ = Describe("Base", func() {
 		c, err := api.NewClient(cfg)
 		Expect(err).NotTo(HaveOccurred())
 		consul = c
-		client = NewResourceClient(consul, rootKey, &v1.MockResource{})
+
+		queryOptions := api.QueryOptions{AllowStale: false, RequireConsistent: true}
+		client = NewResourceClient(consul, rootKey, queryOptions, &v1.MockResource{})
 	})
 	AfterEach(func() {
 		consul.KV().DeleteTree(rootKey, nil)

--- a/pkg/api/v1/clients/factory/resource_client_factory.go
+++ b/pkg/api/v1/clients/factory/resource_client_factory.go
@@ -113,7 +113,7 @@ func newResourceClient(ctx context.Context, factory ResourceClientFactory, param
 		if !ok {
 			return nil, errors.Errorf("the consul storage client can only be used for resources which implement the resources.VersionedResource interface resources, received type %v", resources.Kind(resourceType))
 		}
-		return consul.NewResourceClient(opts.Consul, opts.RootKey, versionedResource), nil
+		return consul.NewResourceClient(opts.Consul, opts.RootKey, opts.QueryOptions, versionedResource), nil
 	case *FileResourceClientFactory:
 		return file.NewResourceClient(opts.RootDir, resourceType), nil
 	case *MemoryResourceClientFactory:
@@ -176,8 +176,9 @@ func (f *KubeResourceClientFactory) NewResourceClient(ctx context.Context, param
 }
 
 type ConsulResourceClientFactory struct {
-	Consul  *api.Client
-	RootKey string
+	Consul       *api.Client
+	RootKey      string
+	QueryOptions api.QueryOptions
 }
 
 func (f *ConsulResourceClientFactory) NewResourceClient(ctx context.Context, params NewResourceClientParams) (clients.ResourceClient, error) {

--- a/pkg/api/v1/clients/factory/resource_client_factory.go
+++ b/pkg/api/v1/clients/factory/resource_client_factory.go
@@ -178,7 +178,7 @@ func (f *KubeResourceClientFactory) NewResourceClient(ctx context.Context, param
 type ConsulResourceClientFactory struct {
 	Consul       *api.Client
 	RootKey      string
-	QueryOptions api.QueryOptions
+	QueryOptions *api.QueryOptions
 }
 
 func (f *ConsulResourceClientFactory) NewResourceClient(ctx context.Context, params NewResourceClientParams) (clients.ResourceClient, error) {


### PR DESCRIPTION
- Added `queryOptions` to the factory (and resource client) set custom Consul query options.
  - Went this route instead of passing in `AllowStale` to the rc client. I did so to make it easier to configure/add to this in the future. We'd just have to add the new option we're adding into the `api.QueryOption{}` we're passing when creating an new client factory in Gloo.