### PR TITLE
Support set-based label selectors

### DIFF
--- a/changelog/v0.27.1/set-based-label-selector.yaml
+++ b/changelog/v0.27.1/set-based-label-selector.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo/issues/6406
+    resolvesIssue: false
+    description: |
+      Add ExpressionSelector to ListOpts and WatchOpts.
+      This adds support to set-based label selection on resource clients, allowing selection
+      of resources with multiple values for the same key. Previously, only equality-based
+      label selection was supported, which required a single key and value for all defined requirements.

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/solo-io/anyvendor v0.0.1
 	github.com/solo-io/go-list-licenses v0.0.4
 	github.com/solo-io/go-utils v0.21.6
-	github.com/solo-io/k8s-utils v0.0.8
+	github.com/solo-io/k8s-utils v0.1.0
 	github.com/solo-io/protoc-gen-ext v0.0.16
 	github.com/solo-io/protoc-gen-openapi v0.0.1
 	github.com/spf13/afero v1.3.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -782,8 +782,8 @@ github.com/solo-io/go-list-licenses v0.0.4/go.mod h1:x6LSp/NrYgVXwNum7ZOiaAYTpg6
 github.com/solo-io/go-utils v0.20.2/go.mod h1:6e8K1spnMWwlnJRSNp/J84GEyJbrcK4Gm7i+ehzCi8c=
 github.com/solo-io/go-utils v0.21.6 h1:QTRrYJUK31p6IRqR3A1Y9H4MXgl1eOB4cZdD0o5gIhc=
 github.com/solo-io/go-utils v0.21.6/go.mod h1:N6jeYnrAKq5uGv6m/hBkJ+g6i3AwgkyfVoaDlQ/z64o=
-github.com/solo-io/k8s-utils v0.0.8 h1:GJ+DLBFfR8WRg2WofGQ3o3DVPByDEYgANX9kQYhprow=
-github.com/solo-io/k8s-utils v0.0.8/go.mod h1:Cg2ymG0xhLdyS3NJ0D98yxiSWjAKYPNopzPTwVDl7e4=
+github.com/solo-io/k8s-utils v0.1.0 h1:podyELsbIkkdmu5xx6+y1dd6OUIt8Tv2XqAttUPI1VI=
+github.com/solo-io/k8s-utils v0.1.0/go.mod h1:Cg2ymG0xhLdyS3NJ0D98yxiSWjAKYPNopzPTwVDl7e4=
 github.com/solo-io/protoc-gen-ext v0.0.16 h1:PHPzkmK6FVtMlDe95WSOcSXKSdnfUxuwJMfet/PaLhU=
 github.com/solo-io/protoc-gen-ext v0.0.16/go.mod h1:j5wvKW5B7oes0hf46IxPDEkDK0pNNQ1Nbfrr1P+xBQo=
 github.com/solo-io/protoc-gen-openapi v0.0.1 h1:/VMAtc010Qcpo2Zm/RsRke3Fu27z3eraF9Tmgoe4QHA=

--- a/pkg/api/v1/clients/client_interface.go
+++ b/pkg/api/v1/clients/client_interface.go
@@ -104,9 +104,10 @@ func (o DeleteOpts) WithDefaults() DeleteOpts {
 }
 
 type ListOpts struct {
-	Ctx      context.Context
-	Selector map[string]string
-	Cluster  string
+	Ctx                context.Context
+	Selector           map[string]string
+	ExpressionSelector string
+	Cluster            string
 }
 
 func (o ListOpts) WithDefaults() ListOpts {
@@ -120,9 +121,10 @@ func (o ListOpts) WithDefaults() ListOpts {
 // To achieve a similar behavior you can use the KubeResourceClientFactory.ResyncPeriod field. The difference is that it
 // will apply to all the watches started by clients built with the factory.
 type WatchOpts struct {
-	Ctx         context.Context
-	Selector    map[string]string
-	RefreshRate time.Duration
+	Ctx                context.Context
+	Selector           map[string]string
+	ExpressionSelector string
+	RefreshRate        time.Duration
 	// Cluster is ignored by aggregated watches, but is respected by multi cluster clients.
 	Cluster string
 }

--- a/pkg/api/v1/clients/client_interface.go
+++ b/pkg/api/v1/clients/client_interface.go
@@ -104,10 +104,28 @@ func (o DeleteOpts) WithDefaults() DeleteOpts {
 }
 
 type ListOpts struct {
-	Ctx                context.Context
-	Selector           map[string]string
+	Ctx     context.Context
+	Cluster string
+
+	// Equality-based label requirements
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#equality-based-requirement
+	// Equality--based requirements allow filtering by label keys and values.
+	// Matching objects must satisfy all of the specified label constraints,
+	// though they may have additional labels as well.
+	// Example:
+	//	{product: edge} would return all objects with a label key equal to
+	//	product and label value equal to edge
+	// If both ExpressionSelector and Selector are defined, ExpressionSelector is preferred
+	Selector map[string]string
+	// Set-based label requirements
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement
+	// Set-based label requirements allow filtering keys according to a set of values.
+	// Three kinds of operators are supported: in,notin and exists (only the key identifier).
+	// Example:
+	//	"product in (edge, mesh)" would return all objects with the label key equal to product
+	//	and value equal to edge or mesh
+	// If both ExpressionSelector and Selector are defined, ExpressionSelector is preferred
 	ExpressionSelector string
-	Cluster            string
 }
 
 func (o ListOpts) WithDefaults() ListOpts {
@@ -121,8 +139,26 @@ func (o ListOpts) WithDefaults() ListOpts {
 // To achieve a similar behavior you can use the KubeResourceClientFactory.ResyncPeriod field. The difference is that it
 // will apply to all the watches started by clients built with the factory.
 type WatchOpts struct {
-	Ctx                context.Context
-	Selector           map[string]string
+	Ctx context.Context
+
+	// Equality-based label requirements
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#equality-based-requirement
+	// Equality--based requirements allow filtering by label keys and values.
+	// Matching objects must satisfy all of the specified label constraints,
+	// though they may have additional labels as well.
+	// Example:
+	//	{product: edge} would return all objects with a label key equal to
+	//	product and label value equal to edge
+	// If both ExpressionSelector and Selector are defined, ExpressionSelector is preferred
+	Selector map[string]string
+	// Set-based label requirements
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement
+	// Set-based label requirements allow filtering keys according to a set of values.
+	// Three kinds of operators are supported: in,notin and exists (only the key identifier).
+	// Example:
+	//	"product in (edge, mesh)" would return all objects with the label key equal to product
+	//	and value equal to edge or mesh
+	// If both ExpressionSelector and Selector are defined, ExpressionSelector is preferred
 	ExpressionSelector string
 	RefreshRate        time.Duration
 	// Cluster is ignored by aggregated watches, but is respected by multi cluster clients.

--- a/pkg/api/v1/clients/client_interface.go
+++ b/pkg/api/v1/clients/client_interface.go
@@ -109,7 +109,7 @@ type ListOpts struct {
 
 	// Equality-based label requirements
 	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#equality-based-requirement
-	// Equality--based requirements allow filtering by label keys and values.
+	// Equality-based requirements allow filtering by label keys and values.
 	// Matching objects must satisfy all of the specified label constraints,
 	// though they may have additional labels as well.
 	// Example:
@@ -143,7 +143,7 @@ type WatchOpts struct {
 
 	// Equality-based label requirements
 	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#equality-based-requirement
-	// Equality--based requirements allow filtering by label keys and values.
+	// Equality-based requirements allow filtering by label keys and values.
 	// Matching objects must satisfy all of the specified label constraints,
 	// though they may have additional labels as well.
 	// Example:

--- a/pkg/api/v1/clients/kube/resource_client.go
+++ b/pkg/api/v1/clients/kube/resource_client.go
@@ -294,10 +294,17 @@ func (rc *ResourceClient) List(namespace string, opts clients.ListOpts) (resourc
 	if err != nil {
 		return nil, err
 	}
-	allResources, err := lister.List(labels.SelectorFromSet(opts.Selector))
+
+	labelSelector, err := rc.getLabelSelector(opts)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parsing label selector")
+	}
+
+	allResources, err := lister.List(labelSelector)
 	if err != nil {
 		return nil, errors.Wrapf(err, "listing resources in %v", namespace)
 	}
+
 	var listedResources []*v1.Resource
 	if namespace != "" {
 		for _, r := range allResources {
@@ -343,8 +350,9 @@ func (rc *ResourceClient) Watch(namespace string, opts clients.WatchOpts) (<-cha
 
 	updateResourceList := func() {
 		list, err := rc.List(namespace, clients.ListOpts{
-			Ctx:      ctx,
-			Selector: opts.Selector,
+			Ctx:                ctx,
+			Selector:           opts.Selector,
+			ExpressionSelector: opts.ExpressionSelector,
 		})
 		if err != nil {
 			errs <- err
@@ -403,6 +411,16 @@ func (rc *ResourceClient) Watch(namespace string, opts clients.WatchOpts) (<-cha
 	}(namespace)
 
 	return resourcesChan, errs, nil
+}
+
+func (rc *ResourceClient) getLabelSelector(listOpts clients.ListOpts) (labels.Selector, error) {
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement
+	if listOpts.ExpressionSelector != "" {
+		return labels.Parse(listOpts.ExpressionSelector)
+	}
+
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#equality-based-requirement
+	return labels.SelectorFromSet(listOpts.Selector), nil
 }
 
 // Checks whether the group version kind of the given resource matches that of the client's underlying CRD:

--- a/pkg/api/v1/clients/kube/resource_client_test.go
+++ b/pkg/api/v1/clients/kube/resource_client_test.go
@@ -677,6 +677,11 @@ var _ = Describe("Test Kube ResourceClient", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(list).To(HaveLen(1))
+
+				list, err = rc.List(namespace1, clients.ListOpts{
+					ExpressionSelector: "invalid expression to parse",
+				})
+				Expect(err).To(HaveOccurred())
 			})
 
 			It("lists the correct resources using order: set-based, equality-based", func() {

--- a/pkg/api/v1/clients/kube/resource_client_test.go
+++ b/pkg/api/v1/clients/kube/resource_client_test.go
@@ -2,6 +2,7 @@ package kube_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -558,11 +559,44 @@ var _ = Describe("Test Kube ResourceClient", func() {
 			BeforeEach(func() {
 				clientset = fake.NewSimpleClientset(v1.MockResourceCrd)
 
-				// Create initial resources
-				Expect(util.CreateMockResource(ctx, clientset, namespace1, "res-1", "val-1")).NotTo(HaveOccurred())
-				Expect(util.CreateMockResource(ctx, clientset, namespace1, "res-2", "val-2")).NotTo(HaveOccurred())
-				Expect(util.CreateMockResource(ctx, clientset, namespace1, "res-3", "val-3")).NotTo(HaveOccurred())
-				Expect(util.CreateMockResource(ctx, clientset, namespace2, "res-4", "val-4")).NotTo(HaveOccurred())
+				metadataForMockResources := []*core.Metadata{
+					{
+						Name:      "res-1",
+						Namespace: namespace1,
+						Labels: map[string]string{
+							"name":      "res-1",
+							"namespace": namespace1,
+						},
+					},
+					{
+						Name:      "res-2",
+						Namespace: namespace1,
+						Labels: map[string]string{
+							"name":      "res-2",
+							"namespace": namespace1,
+						},
+					},
+					{
+						Name:      "res-3",
+						Namespace: namespace1,
+						Labels: map[string]string{
+							"name":      "res-3",
+							"namespace": namespace1,
+						},
+					},
+					{
+						Name:      "res-4",
+						Namespace: namespace2,
+						Labels: map[string]string{
+							"name":      "res-4",
+							"namespace": namespace2,
+						},
+					},
+				}
+
+				for i, meta := range metadataForMockResources {
+					Expect(util.CreateMockResourceWithMetadata(ctx, clientset, meta, fmt.Sprintf("val-%d", i)))
+				}
 				// v2alpha1 resources should be ignored by this v1 MockResource client
 				Expect(util.CreateV2Alpha1MockResource(ctx, clientset, namespace2, "res-5", "val-5")).NotTo(HaveOccurred())
 
@@ -590,6 +624,61 @@ var _ = Describe("Test Kube ResourceClient", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(list).To(HaveLen(0))
 			})
+
+			It("lists the correct resources for the given equality-based label selector", func() {
+				list, err := rc.List(namespace1, clients.ListOpts{
+					Selector: map[string]string{
+						"namespace": namespace1,
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(list).To(HaveLen(3))
+
+				list, err = rc.List(namespace1, clients.ListOpts{
+					Selector: map[string]string{
+						"name": "res-1",
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(list).To(HaveLen(1))
+
+				// equality-based selector use AND to join requirements
+				list, err = rc.List(namespace1, clients.ListOpts{
+					Selector: map[string]string{
+						"namespace": namespace1,
+						"name":      "res-1",
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(list).To(HaveLen(1))
+			})
+
+			It("lists the correct resources for the given set-based label selector", func() {
+				list, err := rc.List(namespace1, clients.ListOpts{
+					ExpressionSelector: fmt.Sprintf("namespace in (%s)", namespace1),
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(list).To(HaveLen(3))
+
+				list, err = rc.List(namespace1, clients.ListOpts{
+					ExpressionSelector: fmt.Sprintf("namespace in (%s)", namespace2),
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(list).To(HaveLen(0))
+
+				list, err = rc.List(namespace1, clients.ListOpts{
+					ExpressionSelector: fmt.Sprintf("namespace in (%s,%s)", namespace1, namespace2),
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(list).To(HaveLen(3))
+
+				list, err = rc.List(namespace1, clients.ListOpts{
+					ExpressionSelector: fmt.Sprintf("namespace in (%s,%s),name in (%s)", namespace1, namespace2, "res-1"),
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(list).To(HaveLen(1))
+			})
+
 		})
 
 		Describe("deleting resources", func() {

--- a/pkg/api/v1/clients/kube/resource_client_test.go
+++ b/pkg/api/v1/clients/kube/resource_client_test.go
@@ -679,6 +679,27 @@ var _ = Describe("Test Kube ResourceClient", func() {
 				Expect(list).To(HaveLen(1))
 			})
 
+			It("lists the correct resources using order: set-based, equality-based", func() {
+				// uses ExpressionSelector if defined
+				list, err := rc.List(namespace1, clients.ListOpts{
+					Selector: map[string]string{
+						"invalid-key": "invalid-value",
+					},
+					ExpressionSelector: fmt.Sprintf("namespace in (%s)", namespace1),
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(list).To(HaveLen(3))
+
+				// fallback to Selector if no ExpressionSelector is defined
+				list, err = rc.List(namespace1, clients.ListOpts{
+					Selector: map[string]string{
+						"invalid-key": "invalid-value",
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(list).To(HaveLen(0))
+			})
+
 		})
 
 		Describe("deleting resources", func() {

--- a/test/util/utils.go
+++ b/test/util/utils.go
@@ -40,15 +40,22 @@ func MockClientForNamespace(cache kube.SharedCache, namespaces []string, podName
 }
 
 func CreateMockResource(ctx context.Context, cs *fake.Clientset, namespace, name, dumbFieldValue string) error {
+	return CreateMockResourceWithMetadata(ctx, cs, &core.Metadata{
+		Name:      name,
+		Namespace: namespace,
+	}, dumbFieldValue)
+}
+
+func CreateMockResourceWithMetadata(ctx context.Context, cs *fake.Clientset, metadata *core.Metadata, dumbFieldValue string) error {
 	kubeResource, err := v1.MockResourceCrd.KubeResource(&v1.MockResource{
-		Metadata:      &core.Metadata{Name: name},
+		Metadata:      metadata,
 		SomeDumbField: dumbFieldValue,
 	})
 	if err != nil {
 		return err
 	}
 
-	_, err = cs.ResourcesV1().Resources(namespace).Create(ctx, kubeResource, metav1.CreateOptions{})
+	_, err = cs.ResourcesV1().Resources(metadata.GetNamespace()).Create(ctx, kubeResource, metav1.CreateOptions{})
 	return err
 }
 


### PR DESCRIPTION
# Description
Add support for resource clients to select objections with labels using an expression

# Context
The label selector is the core grouping primitive in Kubernetes. In solo-kit we previously only supported selecting resources from the apiserver via [equality-based requirements](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#equality-based-requirement). 

## Why is this helpful?
Gloo clients should support the full feature-set of the Kubernetes API. 

Additionally, when Gloo controllers make changes to labels, we need to be able to support the intermediary period where we are looking for labels with multiple values.

## Is this backwards compatible?
Yes. This PR exposes the injection of an "ExpressionSelector". It is the preferred mechanism for defining selection, since it is the more powerful of the two. However, if it is not defined (as will be the case for all clients that upgrade to this version) we fallback to the original implementation which relies on the "Selector".

## How is this tested?
- [x] There are e2e tests defined, which create resources with varying labels, and then use resource clients to list those resources and validate the objects returned.
- [x]  There are e2e tests defined, which create resources with varying labels, and then use resource clients to list those resources and validate the objects returned.
- [x] There is a Gloo PR which incorporates these changes and proves it works as expected.  This isn't entirely necessary, since the changes can/should be able to validated within this library. https://github.com/solo-io/gloo/pull/6461 I was able to run the new regression test locally as well.