### PR TITLE
v0.20 never error on status usage

### DIFF
--- a/changelog/v0.20.8/never-error-on-statuses.yaml
+++ b/changelog/v0.20.8/never-error-on-statuses.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-kit/issues/484
+    resolvesIssue: false
+    description: |
+      Dont error on statuses. This allows for downgrades.

--- a/pkg/api/v1/clients/kube/crd/crd.go
+++ b/pkg/api/v1/clients/kube/crd/crd.go
@@ -89,10 +89,7 @@ func (d Crd) KubeResource(resource resources.InputResource) (*v1.Resource, error
 		if err != nil {
 			return nil, MarshalErr(err, "resource spec to map")
 		}
-		status, err = customResource.MarshalStatus()
-		if err != nil {
-			return nil, MarshalErr(err, "resource status to map")
-		}
+		status, _ = customResource.MarshalStatus()
 
 	} else {
 		// Default marshalling
@@ -108,10 +105,7 @@ func (d Crd) KubeResource(resource resources.InputResource) (*v1.Resource, error
 
 		if resource.GetStatus() != nil {
 			statusProto := resource.GetStatus()
-			statusMap, err := protoutils.MarshalMapFromProtoWithEnumsAsInts(statusProto)
-			if err != nil {
-				return nil, MarshalErr(err, "resource status to map")
-			}
+			statusMap, _ := protoutils.MarshalMapFromProtoWithEnumsAsInts(statusProto)
 			status = statusMap
 		}
 	}

--- a/pkg/api/v1/clients/kube/resource_client.go
+++ b/pkg/api/v1/clients/kube/resource_client.go
@@ -435,10 +435,10 @@ func (rc *ResourceClient) convertCrdToResource(resourceCrd *v1.Resource) (resour
 					resourceCrd.Name, resourceCrd.Namespace, rc.resourceName)
 			}
 		}
-		if err := customResource.UnmarshalStatus(resourceCrd.Status); err != nil {
-			return nil, errors.Wrapf(err, "unmarshalling crd status on custom resource %v in namespace %v into %v",
-				resourceCrd.Name, resourceCrd.Namespace, rc.resourceName)
-		}
+		// If the status is of a form that we do not recognize, we should ignore it.
+		// Support backports of custom resources that do not have a status fields
+		// in the way we want.
+		_ = customResource.UnmarshalStatus(resourceCrd.Status)
 
 	} else {
 		// Default unmarshalling
@@ -451,9 +451,7 @@ func (rc *ResourceClient) convertCrdToResource(resourceCrd *v1.Resource) (resour
 					return nil
 				}
 				typedStatus := core.Status{}
-				if err := protoutils.UnmarshalMapToProto(resourceCrd.Status, &typedStatus); err != nil {
-					return err
-				}
+				_ = protoutils.UnmarshalMapToProto(resourceCrd.Status, &typedStatus)
 				*status = typedStatus
 				return nil
 			}


### PR DESCRIPTION
Never error on statuses.

In this (unlike in newer versions) status is a map so as it is not a pointer we are safe to do it this way..