### PR TITLE
Unmarshal FollowUp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ verify-envoy-protos:
 .PHONY: test
 test:
 ifneq ($(RELEASE), "true")
-	PATH=$(DEPSGOBIN):$$PATH ginkgo -r  -v -race -tags solokit -compilers=2 -skip multicluster -regexScansFilePath $(TEST_PKG)
+	PATH=$(DEPSGOBIN):$$PATH ginkgo -r -v -race -p -tags solokit -compilers=2 -skip multicluster -regexScansFilePath $(TEST_PKG)
 endif
 
 #----------------------------------------------------------------------------------

--- a/changelog/v0.20.11/kube-client-improvements.yaml
+++ b/changelog/v0.20.11/kube-client-improvements.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: |
+      Ensure that UnmarshalResource performs a strict unmarshal and does not allow unknown fields.
+      This method is used by the validation webhook in Gloo Edge.

--- a/pkg/utils/protoutils/marshal.go
+++ b/pkg/utils/protoutils/marshal.go
@@ -7,8 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 
-	"github.com/solo-io/solo-kit/pkg/utils/specutils"
-
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	structpb "github.com/golang/protobuf/ptypes/struct"
@@ -183,7 +181,8 @@ func MapStringInterfaceToMapStringString(interfaceMap map[string]interface{}) (m
 	return stringMap, nil
 }
 
-// convert raw Kube JSON to a Solo-Kit resource
+// UnmarshalResource convert raw Kube JSON to a Solo-Kit resource
+// Returns an error if unknown fields are present in the raw json
 func UnmarshalResource(kubeJson []byte, resource resources.Resource) error {
 	var resourceCrd v1.Resource
 	if err := json.Unmarshal(kubeJson, &resourceCrd); err != nil {
@@ -211,7 +210,7 @@ func UnmarshalResource(kubeJson []byte, resource resources.Resource) error {
 	}
 
 	if resourceCrd.Spec != nil {
-		if err := specutils.UnmarshalSpecMapToResource(*resourceCrd.Spec, resource); err != nil {
+		if err := UnmarshalMap(*resourceCrd.Spec, resource); err != nil {
 			return errors.Wrapf(err, "parsing resource from crd spec %v in namespace %v into %T", resourceCrd.Name, resourceCrd.Namespace, resource)
 		}
 	}


### PR DESCRIPTION
The gloo validation webhook relies on this method (https://github.com/solo-io/gloo/blob/master/projects/gateway/pkg/validation/validator.go#L428) and we need the unmarshaling to not allow unknown fields. 

This reverts the change introduced https://github.com/solo-io/solo-kit/pull/502