### PR TITLE
Ratelimit emitters

### DIFF
--- a/changelog/v0.30.3/ratelimit_emitters.yaml
+++ b/changelog/v0.30.3/ratelimit_emitters.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6599
+    resolvesIssue: false
+    description: Ratelimit emitters to once per second so Sync loops acting on Snapshot() have time to finish before being cancelled.

--- a/pkg/api/v1/clients/kube/resource_client.go
+++ b/pkg/api/v1/clients/kube/resource_client.go
@@ -382,8 +382,6 @@ func (rc *ResourceClient) Watch(namespace string, opts clients.WatchOpts) (<-cha
 		defer close(resourcesChan)
 		defer close(errs)
 
-		// Perform an initial list operation
-
 		timer := time.NewTicker(time.Second)
 		defer timer.Stop()
 
@@ -393,7 +391,6 @@ func (rc *ResourceClient) Watch(namespace string, opts clients.WatchOpts) (<-cha
 		for {
 			select {
 			case resource := <-cacheUpdated:
-
 				// Only notify watchers if the updated resource is in the watched
 				// namespace and its kind matches the one of the resource clientz
 				if matchesTargetNamespace(watchedNamespace, resource.ObjectMeta.Namespace) && rc.matchesClientGVK(resource) {

--- a/pkg/code-generator/codegen/templates/snapshot_simple_emitter_template.go
+++ b/pkg/code-generator/codegen/templates/snapshot_simple_emitter_template.go
@@ -57,22 +57,24 @@ func (c *{{ lower_camel .GoName }}SimpleEmitter) Snapshots(ctx context.Context) 
 
 	go func() {
 		currentSnapshot := {{ .GoName }}Snapshot{}
+		needsSync := false
+		// intentionally rate-limited so that our sync loops have time to complete before the next snapshot is sent
 		timer := time.NewTicker(time.Second * 1)
+		defer timer.Stop()
 		var previousHash uint64
 		sync := func() {
 			currentHash, err := currentSnapshot.Hash(nil)
 			if err != nil {
 				contextutils.LoggerFrom(ctx).Panicw("error while hashing, this should never happen", zap.Error(err))
 			}
-			if previousHash == currentHash {
+			if !needsSync && previousHash == currentHash {
 				return
 			}
-
 			previousHash = currentHash
-
 			stats.Record(ctx, m{{ .GoName }}SnapshotOut.M(1))
 			sentSnapshot := currentSnapshot.Clone()
 			snapshots <- &sentSnapshot
+			needsSync = false
 		}
 
 		defer func() {
@@ -89,11 +91,9 @@ func (c *{{ lower_camel .GoName }}SimpleEmitter) Snapshots(ctx context.Context) 
 			case <-ctx.Done():
 				return
 			case <-c.forceEmit:
-				sentSnapshot := currentSnapshot.Clone()
-				snapshots <- &sentSnapshot
+				needsSync = true
 			case untypedList := <-untyped:
 				record()
-
 				currentSnapshot = {{ .GoName }}Snapshot{}
 				for _, res := range untypedList {
 					switch typed := res.(type) {

--- a/pkg/multicluster/v1/kubeconfigs_snapshot_simple_emitter.sk.go
+++ b/pkg/multicluster/v1/kubeconfigs_snapshot_simple_emitter.sk.go
@@ -48,22 +48,24 @@ func (c *kubeconfigsSimpleEmitter) Snapshots(ctx context.Context) (<-chan *Kubec
 
 	go func() {
 		currentSnapshot := KubeconfigsSnapshot{}
+		needsSync := false
+		// intentionally rate-limited so that our sync loops have time to complete before the next snapshot is sent
 		timer := time.NewTicker(time.Second * 1)
+		defer timer.Stop()
 		var previousHash uint64
 		sync := func() {
 			currentHash, err := currentSnapshot.Hash(nil)
 			if err != nil {
 				contextutils.LoggerFrom(ctx).Panicw("error while hashing, this should never happen", zap.Error(err))
 			}
-			if previousHash == currentHash {
+			if !needsSync && previousHash == currentHash {
 				return
 			}
-
 			previousHash = currentHash
-
 			stats.Record(ctx, mKubeconfigsSnapshotOut.M(1))
 			sentSnapshot := currentSnapshot.Clone()
 			snapshots <- &sentSnapshot
+			needsSync = false
 		}
 
 		defer func() {
@@ -80,11 +82,9 @@ func (c *kubeconfigsSimpleEmitter) Snapshots(ctx context.Context) (<-chan *Kubec
 			case <-ctx.Done():
 				return
 			case <-c.forceEmit:
-				sentSnapshot := currentSnapshot.Clone()
-				snapshots <- &sentSnapshot
+				needsSync = true
 			case untypedList := <-untyped:
 				record()
-
 				currentSnapshot = KubeconfigsSnapshot{}
 				for _, res := range untypedList {
 					switch typed := res.(type) {

--- a/test/mocks/v1/testing_snapshot_emitter.sk.go
+++ b/test/mocks/v1/testing_snapshot_emitter.sk.go
@@ -460,7 +460,10 @@ func (c *testingEmitter) Snapshots(watchNamespaces []string, opts clients.WatchO
 		initialSnapshot := currentSnapshot.Clone()
 		snapshots <- &initialSnapshot
 
+		needsSync := false
+		// intentionally rate-limited so that our sync loops have time to complete before the next snapshot is sent
 		timer := time.NewTicker(time.Second * 1)
+		defer timer.Stop()
 		previousHash, err := currentSnapshot.Hash(nil)
 		if err != nil {
 			contextutils.LoggerFrom(ctx).Panicw("error while hashing, this should never happen", zap.Error(err))
@@ -471,7 +474,7 @@ func (c *testingEmitter) Snapshots(watchNamespaces []string, opts clients.WatchO
 			if err != nil {
 				contextutils.LoggerFrom(ctx).Panicw("error while hashing, this should never happen", zap.Error(err))
 			}
-			if previousHash == currentHash {
+			if !needsSync && previousHash == currentHash {
 				return
 			}
 
@@ -480,6 +483,7 @@ func (c *testingEmitter) Snapshots(watchNamespaces []string, opts clients.WatchO
 			case snapshots <- &sentSnapshot:
 				stats.Record(ctx, mTestingSnapshotOut.M(1))
 				previousHash = currentHash
+				needsSync = false
 			default:
 				stats.Record(ctx, mTestingSnapshotMissed.M(1))
 			}
@@ -501,8 +505,7 @@ func (c *testingEmitter) Snapshots(watchNamespaces []string, opts clients.WatchO
 			case <-ctx.Done():
 				return
 			case <-c.forceEmit:
-				sentSnapshot := currentSnapshot.Clone()
-				snapshots <- &sentSnapshot
+				needsSync = true
 			case simpleMockResourceNamespacedList, ok := <-simpleMockResourceChan:
 				if !ok {
 					return

--- a/test/mocks/v1/testing_snapshot_simple_emitter.sk.go
+++ b/test/mocks/v1/testing_snapshot_simple_emitter.sk.go
@@ -50,22 +50,24 @@ func (c *testingSimpleEmitter) Snapshots(ctx context.Context) (<-chan *TestingSn
 
 	go func() {
 		currentSnapshot := TestingSnapshot{}
+		needsSync := false
+		// intentionally rate-limited so that our sync loops have time to complete before the next snapshot is sent
 		timer := time.NewTicker(time.Second * 1)
+		defer timer.Stop()
 		var previousHash uint64
 		sync := func() {
 			currentHash, err := currentSnapshot.Hash(nil)
 			if err != nil {
 				contextutils.LoggerFrom(ctx).Panicw("error while hashing, this should never happen", zap.Error(err))
 			}
-			if previousHash == currentHash {
+			if !needsSync && previousHash == currentHash {
 				return
 			}
-
 			previousHash = currentHash
-
 			stats.Record(ctx, mTestingSnapshotOut.M(1))
 			sentSnapshot := currentSnapshot.Clone()
 			snapshots <- &sentSnapshot
+			needsSync = false
 		}
 
 		defer func() {
@@ -82,11 +84,9 @@ func (c *testingSimpleEmitter) Snapshots(ctx context.Context) (<-chan *TestingSn
 			case <-ctx.Done():
 				return
 			case <-c.forceEmit:
-				sentSnapshot := currentSnapshot.Clone()
-				snapshots <- &sentSnapshot
+				needsSync = true
 			case untypedList := <-untyped:
 				record()
-
 				currentSnapshot = TestingSnapshot{}
 				for _, res := range untypedList {
 					switch typed := res.(type) {

--- a/test/mocks/v1alpha1/testing_snapshot_emitter.sk.go
+++ b/test/mocks/v1alpha1/testing_snapshot_emitter.sk.go
@@ -187,7 +187,10 @@ func (c *testingEmitter) Snapshots(watchNamespaces []string, opts clients.WatchO
 		initialSnapshot := currentSnapshot.Clone()
 		snapshots <- &initialSnapshot
 
+		needsSync := false
+		// intentionally rate-limited so that our sync loops have time to complete before the next snapshot is sent
 		timer := time.NewTicker(time.Second * 1)
+		defer timer.Stop()
 		previousHash, err := currentSnapshot.Hash(nil)
 		if err != nil {
 			contextutils.LoggerFrom(ctx).Panicw("error while hashing, this should never happen", zap.Error(err))
@@ -198,7 +201,7 @@ func (c *testingEmitter) Snapshots(watchNamespaces []string, opts clients.WatchO
 			if err != nil {
 				contextutils.LoggerFrom(ctx).Panicw("error while hashing, this should never happen", zap.Error(err))
 			}
-			if previousHash == currentHash {
+			if !needsSync && previousHash == currentHash {
 				return
 			}
 
@@ -207,6 +210,7 @@ func (c *testingEmitter) Snapshots(watchNamespaces []string, opts clients.WatchO
 			case snapshots <- &sentSnapshot:
 				stats.Record(ctx, mTestingSnapshotOut.M(1))
 				previousHash = currentHash
+				needsSync = false
 			default:
 				stats.Record(ctx, mTestingSnapshotMissed.M(1))
 			}
@@ -228,8 +232,7 @@ func (c *testingEmitter) Snapshots(watchNamespaces []string, opts clients.WatchO
 			case <-ctx.Done():
 				return
 			case <-c.forceEmit:
-				sentSnapshot := currentSnapshot.Clone()
-				snapshots <- &sentSnapshot
+				needsSync = true
 			case mockResourceNamespacedList, ok := <-mockResourceChan:
 				if !ok {
 					return

--- a/test/mocks/v1alpha1/testing_snapshot_simple_emitter.sk.go
+++ b/test/mocks/v1alpha1/testing_snapshot_simple_emitter.sk.go
@@ -48,22 +48,24 @@ func (c *testingSimpleEmitter) Snapshots(ctx context.Context) (<-chan *TestingSn
 
 	go func() {
 		currentSnapshot := TestingSnapshot{}
+		needsSync := false
+		// intentionally rate-limited so that our sync loops have time to complete before the next snapshot is sent
 		timer := time.NewTicker(time.Second * 1)
+		defer timer.Stop()
 		var previousHash uint64
 		sync := func() {
 			currentHash, err := currentSnapshot.Hash(nil)
 			if err != nil {
 				contextutils.LoggerFrom(ctx).Panicw("error while hashing, this should never happen", zap.Error(err))
 			}
-			if previousHash == currentHash {
+			if !needsSync && previousHash == currentHash {
 				return
 			}
-
 			previousHash = currentHash
-
 			stats.Record(ctx, mTestingSnapshotOut.M(1))
 			sentSnapshot := currentSnapshot.Clone()
 			snapshots <- &sentSnapshot
+			needsSync = false
 		}
 
 		defer func() {
@@ -80,11 +82,9 @@ func (c *testingSimpleEmitter) Snapshots(ctx context.Context) (<-chan *TestingSn
 			case <-ctx.Done():
 				return
 			case <-c.forceEmit:
-				sentSnapshot := currentSnapshot.Clone()
-				snapshots <- &sentSnapshot
+				needsSync = true
 			case untypedList := <-untyped:
 				record()
-
 				currentSnapshot = TestingSnapshot{}
 				for _, res := range untypedList {
 					switch typed := res.(type) {

--- a/test/mocks/v2alpha1/testing_snapshot_simple_emitter.sk.go
+++ b/test/mocks/v2alpha1/testing_snapshot_simple_emitter.sk.go
@@ -50,22 +50,24 @@ func (c *testingSimpleEmitter) Snapshots(ctx context.Context) (<-chan *TestingSn
 
 	go func() {
 		currentSnapshot := TestingSnapshot{}
+		needsSync := false
+		// intentionally rate-limited so that our sync loops have time to complete before the next snapshot is sent
 		timer := time.NewTicker(time.Second * 1)
+		defer timer.Stop()
 		var previousHash uint64
 		sync := func() {
 			currentHash, err := currentSnapshot.Hash(nil)
 			if err != nil {
 				contextutils.LoggerFrom(ctx).Panicw("error while hashing, this should never happen", zap.Error(err))
 			}
-			if previousHash == currentHash {
+			if !needsSync && previousHash == currentHash {
 				return
 			}
-
 			previousHash = currentHash
-
 			stats.Record(ctx, mTestingSnapshotOut.M(1))
 			sentSnapshot := currentSnapshot.Clone()
 			snapshots <- &sentSnapshot
+			needsSync = false
 		}
 
 		defer func() {
@@ -82,11 +84,9 @@ func (c *testingSimpleEmitter) Snapshots(ctx context.Context) (<-chan *TestingSn
 			case <-ctx.Done():
 				return
 			case <-c.forceEmit:
-				sentSnapshot := currentSnapshot.Clone()
-				snapshots <- &sentSnapshot
+				needsSync = true
 			case untypedList := <-untyped:
 				record()
-
 				currentSnapshot = TestingSnapshot{}
 				for _, res := range untypedList {
 					switch typed := res.(type) {


### PR DESCRIPTION
Ratelimit emitters to once per second so Sync loops acting on Snapshot() have time to finish before being cancelled.