### PR TITLE
Omit status if too large

### DIFF
--- a/changelog/v0.30.6/omit-status-patch-too-large.yaml
+++ b/changelog/v0.30.6/omit-status-patch-too-large.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    resolvesIssue: false
+    description: Skip the status patch if it's too large to protect etcd and k8s communication. 
+    issueLink: https://github.com/solo-io/solo-kit/issues/523

--- a/pkg/api/external/kubernetes/customresourcedefinition/resource_client.go
+++ b/pkg/api/external/kubernetes/customresourcedefinition/resource_client.go
@@ -134,7 +134,7 @@ func (rc *customResourceDefinitionResourceClient) ApplyStatus(statusClient resou
 	}
 	opts = opts.WithDefaults()
 
-	data, err := shared.GetJsonPatchData(inputResource)
+	data, err := shared.GetJsonPatchData(opts.Ctx, inputResource)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting status json patch data")
 	}

--- a/pkg/api/external/kubernetes/deployment/resource_client.go
+++ b/pkg/api/external/kubernetes/deployment/resource_client.go
@@ -133,7 +133,7 @@ func (rc *deploymentResourceClient) ApplyStatus(statusClient resources.StatusCli
 	}
 	opts = opts.WithDefaults()
 
-	data, err := shared.GetJsonPatchData(inputResource)
+	data, err := shared.GetJsonPatchData(opts.Ctx, inputResource)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting status json patch data")
 	}

--- a/pkg/api/external/kubernetes/job/resource_client.go
+++ b/pkg/api/external/kubernetes/job/resource_client.go
@@ -133,7 +133,7 @@ func (rc *jobResourceClient) ApplyStatus(statusClient resources.StatusClient, in
 	}
 	opts = opts.WithDefaults()
 
-	data, err := shared.GetJsonPatchData(inputResource)
+	data, err := shared.GetJsonPatchData(opts.Ctx, inputResource)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting status json patch data")
 	}

--- a/pkg/api/external/kubernetes/namespace/resource_client.go
+++ b/pkg/api/external/kubernetes/namespace/resource_client.go
@@ -132,7 +132,7 @@ func (rc *namespaceResourceClient) ApplyStatus(statusClient resources.StatusClie
 	}
 	opts = opts.WithDefaults()
 
-	data, err := shared.GetJsonPatchData(inputResource)
+	data, err := shared.GetJsonPatchData(opts.Ctx, inputResource)
 	if err != nil {
 		return nil, eris.Wrapf(err, "error getting status json patch data")
 	}

--- a/pkg/api/external/kubernetes/pod/resource_client.go
+++ b/pkg/api/external/kubernetes/pod/resource_client.go
@@ -133,7 +133,7 @@ func (rc *podResourceClient) ApplyStatus(statusClient resources.StatusClient, in
 	}
 	opts = opts.WithDefaults()
 
-	data, err := shared.GetJsonPatchData(inputResource)
+	data, err := shared.GetJsonPatchData(opts.Ctx, inputResource)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting status json patch data")
 	}

--- a/pkg/api/external/kubernetes/service/resource_client.go
+++ b/pkg/api/external/kubernetes/service/resource_client.go
@@ -133,7 +133,7 @@ func (rc *serviceResourceClient) ApplyStatus(statusClient resources.StatusClient
 	}
 	opts = opts.WithDefaults()
 
-	data, err := shared.GetJsonPatchData(inputResource)
+	data, err := shared.GetJsonPatchData(opts.Ctx, inputResource)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting status json patch data")
 	}

--- a/pkg/api/shared/status.go
+++ b/pkg/api/shared/status.go
@@ -2,12 +2,22 @@ package shared
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 
 	"github.com/golang/protobuf/jsonpb"
+	"github.com/solo-io/go-utils/contextutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 	"github.com/solo-io/solo-kit/pkg/errors"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const (
+	// the patch metadata is capped at 2kb of data, for more see https://github.com/solo-io/solo-kit/issues/523
+	// 2147483647 bytes max k8s get from etcd / 2kb per status patch ~= 1 million resources
+	MaxStatusBytes = 2048
 )
 
 // ApplyStatus is used by clients that don't support patch updates to resource statuses (e.g. consul, files, in-memory)
@@ -43,7 +53,7 @@ func ApplyStatus(rc clients.ResourceClient, statusClient resources.StatusClient,
 // GetJsonPatchData returns the json patch data for the input resource.
 // Prefer using json patch for single api call status updates when supported (e.g. k8s) to avoid ratelimiting
 // to the k8s apiserver (e.g. https://github.com/solo-io/gloo/blob/a083522af0a4ce22f4d2adf3a02470f782d5a865/projects/gloo/api/v1/settings.proto#L337-L350)
-func GetJsonPatchData(inputResource resources.InputResource) ([]byte, error) {
+func GetJsonPatchData(ctx context.Context, inputResource resources.InputResource) ([]byte, error) {
 	namespacedStatuses := inputResource.GetNamespacedStatuses().GetStatuses()
 	if len(namespacedStatuses) != 1 {
 		// we only expect our namespace to report here; we don't want to blow away statuses from other reporters
@@ -67,5 +77,15 @@ func GetJsonPatchData(inputResource resources.InputResource) ([]byte, error) {
 	bytes := buf.Bytes()
 	patch := fmt.Sprintf(`[{"op": "replace", "path": "/status/statuses/%s", "value": %s}]`, ns, string(bytes)) // only replace our status so other reporters are not affected (e.g. blue-green of gloo)
 	data := []byte(patch)
+
+	if len(data) > MaxStatusBytes {
+		if contextutils.GetLogLevel() == zapcore.DebugLevel {
+			contextutils.LoggerFrom(ctx).Warnf("status patch is too large, will not apply: %s", data)
+		} else {
+			contextutils.LoggerFrom(ctx).Warnw("status patch is too large, will not apply", zap.Int("status_bytes", len(data)))
+		}
+		return nil, errors.Errorf("patch is too large (%v bytes), max is %v bytes", len(data), MaxStatusBytes)
+	}
+
 	return data, nil
 }

--- a/pkg/api/v1/clients/configmap/resource_client.go
+++ b/pkg/api/v1/clients/configmap/resource_client.go
@@ -123,7 +123,7 @@ func (rc *ResourceClient) ApplyStatus(statusClient resources.StatusClient, input
 	}
 	opts = opts.WithDefaults()
 
-	data, err := shared.GetJsonPatchData(inputResource)
+	data, err := shared.GetJsonPatchData(opts.Ctx, inputResource)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting status json patch data")
 	}

--- a/pkg/api/v1/clients/kube/resource_client.go
+++ b/pkg/api/v1/clients/kube/resource_client.go
@@ -356,7 +356,7 @@ func (rc *ResourceClient) ApplyStatus(statusClient resources.StatusClient, input
 		ctx = ctxWithTags
 	}
 
-	data, err := shared.GetJsonPatchData(inputResource)
+	data, err := shared.GetJsonPatchData(ctx, inputResource)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting status json patch data")
 	}

--- a/pkg/api/v1/clients/kubesecret/resource_client.go
+++ b/pkg/api/v1/clients/kubesecret/resource_client.go
@@ -203,7 +203,7 @@ func (rc *ResourceClient) ApplyStatus(statusClient resources.StatusClient, input
 	}
 	opts = opts.WithDefaults()
 
-	data, err := shared.GetJsonPatchData(inputResource)
+	data, err := shared.GetJsonPatchData(opts.Ctx, inputResource)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting status json patch data")
 	}


### PR DESCRIPTION
Skip the status patch if it's too large to protect etcd and k8s communication.

Related to https://github.com/solo-io/solo-kit/pull/524 which attempts to truncate status so we can still write. If that fails (e.g. opaque struct field is very large) we should still short-circuit and skip writing status to protect etcd