### PR TITLE
Add Gomock intermediate files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ test-report.json
 # junit
 junit.xml
 junit-*.xml
+
+# ignore intermediate files that gomock sometimes generates
+**/gomock_reflect*

--- a/changelog/v0.31.1/gomock-ignore.yaml
+++ b/changelog/v0.31.1/gomock-ignore.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NON_USER_FACING
+  description: >
+    Add intermediate files that gomock sometimes generates to .gitignore
+  issueLink: https://github.com/solo-io/solo-projects/issues/4810
+  resolvesIssue: false


### PR DESCRIPTION
# Description
 - Adds intermediate files that gomock sometimes generates to `.gitignore`
