### PR TITLE
Support validation again snapshot - consistent order of reporter output

### DIFF
--- a/changelog/v0.34.2/consistent-validation-output.yaml
+++ b/changelog/v0.34.2/consistent-validation-output.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Updated reporter validation:
+      * Added ValidateSeparateWarnings to return warnings separately from errors
+      * Added ValidateSeparateWarningsAndErrors to provide a single method to validate and return warnings and errors separately to keep a consistent interface even if warnings will always be `nil`
+      * Updated all Valdiation to return errors and warnings in a consistent order
+    issueLink: https://github.com/solo-io/gloo/issues/8931
+    resolvesIssue: false

--- a/pkg/api/v2/reporter/reporter.go
+++ b/pkg/api/v2/reporter/reporter.go
@@ -246,7 +246,7 @@ func (e ResourceReports) Validate() error {
 		// name/namespace is not unique, so we collect those references together
 		reses := refMap[refKey]
 
-		errsForKey := []error{}
+		var errsForKey []error
 		for _, res := range reses {
 			rpt := e[res]
 
@@ -277,7 +277,7 @@ func (e ResourceReports) ValidateStrict() error {
 	refMap, refKeys := e.refMapAndSortedKeys()
 
 	for _, refKey := range refKeys {
-		errsForKey := []error{}
+		var errsForKey []error
 		reses := refMap[refKey]
 
 		// name/namespace is not unique, so we collect those references together
@@ -317,7 +317,7 @@ func (e ResourceReports) ValidateSeparateWarnings() (error, error) {
 
 	for _, refKey := range refKeys {
 		// name/namespace is not unique, so we collect those references together
-		warnForKey := []error{}
+		var warnForKey []error
 		reses := refMap[refKey]
 
 		for _, res := range reses {

--- a/pkg/api/v2/reporter/reporter.go
+++ b/pkg/api/v2/reporter/reporter.go
@@ -309,64 +309,6 @@ func (e ResourceReports) ValidateStrict() error {
 	return errs
 }
 
-func (e ResourceReports) ValidateSeparateWarnings() (error, error) {
-	var warnings error
-
-	errs := e.Validate()
-	refMap, refKeys := e.refMapAndSortedKeys()
-
-	for _, refKey := range refKeys {
-		// name/namespace is not unique, so we collect those references together
-		var warnForKey []error
-		reses := refMap[refKey]
-
-		for _, res := range reses {
-			rpt := e[res]
-			if len(rpt.Warnings) > 0 {
-				warnForKey = append(warnForKey, errors.Errorf("WARN: \n  %v", rpt.Warnings))
-
-			}
-		}
-
-		if len(warnForKey) > 0 {
-			sortErrors(warnForKey)
-
-			for _, err := range warnForKey {
-				warnings = multierror.Append(warnings, err)
-			}
-		}
-
-	}
-
-	return errs, warnings
-}
-
-// WarningHandling is an enum for how to handle warnings when validating reports with `ValidateWithWarnings`
-type WarningHandling int
-
-const (
-	// With Strict WarningHandling, warnings are treated as errors
-	Strict WarningHandling = iota
-	// With IgnoreWarnings WarningHandling, warnings are ignored
-	IgnoreWarnings
-	// With SeparateWarnings WarningHandling, warnings are returned separately from errors
-	SeparateWarnings
-)
-
-// ValidateReport validates the reports according to the given validation type.
-func (e ResourceReports) ValidateWithWarnings(t WarningHandling) (error, error) {
-	switch t {
-	case Strict:
-		return e.ValidateStrict(), nil
-	case IgnoreWarnings:
-		return e.Validate(), nil
-	case SeparateWarnings:
-		return e.ValidateSeparateWarnings()
-	default:
-		return errors.Errorf("unknown validation type %v", t), nil
-	}
-}
-
 // Minimal set of client operations required for reporters.
 type ReporterResourceClient interface {
 	Kind() string

--- a/pkg/api/v2/reporter/reporter.go
+++ b/pkg/api/v2/reporter/reporter.go
@@ -212,12 +212,16 @@ func (e ResourceReports) refMapAndSortedKeys() (map[string][]resources.InputReso
 		// Get a string representation of the resource ref. This is not guaranteed to be unique.
 		resKey := res.GetMetadata().Ref().String()
 
-		// Add the key to the list of keys if it is not already there
-		if !slices.Contains(refKeys, resKey) {
-			refKeys = append(refKeys, resKey)
-		}
 		// Add the resource to the map of resources with the same key
 		refMap[resKey] = append(refMap[resKey], res)
+	}
+
+	// Get the list of name-namespace keys
+	refKeys = make([]string, len(refMap))
+	i := 0
+	for k := range refMap {
+		refKeys[i] = k
+		i++
 	}
 
 	// Sort the name-namespace keys. This will allow the reports to be accssed in a consistent order,

--- a/pkg/api/v2/reporter/reporter_test.go
+++ b/pkg/api/v2/reporter/reporter_test.go
@@ -541,15 +541,15 @@ var _ = Describe("Reporter", func() {
 				r1.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r1err1"), fmt.Errorf("r1err2"), fmt.Errorf("r1err0")}}, Warnings: []string{"r1warn1", "r1warn2"}},
 				r2.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r2err1")}}},
 				r3.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r3err1")}}, Warnings: []string{"r3warn1", "r3warn0"}},
-				r4.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r4err1")}}},
-				r5.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r0err1")}}},
+				r4.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r4err1")}}, Warnings: []string{"r4warn1", "r4warn0"}},
+				r5.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r0err1")}}, Warnings: []string{"r0warn1"}},
 			}
 		}
 
 		validateReportsReordered := func() rep.ResourceReports {
 			return rep.ResourceReports{
-				r5.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r0err1")}}},
-				r4.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r4err1")}}},
+				r5.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r0err1")}}, Warnings: []string{"r0warn1"}},
+				r4.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r4err1")}}, Warnings: []string{"r4warn1", "r4warn0"}},
 				r3.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r3err1")}}, Warnings: []string{"r3warn1", "r3warn0"}},
 				r2.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r2err1")}}},
 				r1.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r1err1"), fmt.Errorf("r1err2"), fmt.Errorf("r1err0")}}, Warnings: []string{"r1warn1", "r1warn2"}},
@@ -580,7 +580,9 @@ var _ = Describe("Reporter", func() {
 			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r1err0"))
 			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r2err1"))
 			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r3err1"))
+			expectedErr = multierror.Append(expectedErr, errors.Errorf("WARN: \n  %v", []string{"r0warn1"}))
 			expectedErr = multierror.Append(expectedErr, errors.Errorf("WARN: \n  %v", []string{"r1warn1", "r1warn2"}))
+			expectedErr = multierror.Append(expectedErr, errors.Errorf("WARN: \n  %v", []string{"r4warn1", "r4warn0"}))
 			expectedErr = multierror.Append(expectedErr, errors.Errorf("WARN: \n  %v", []string{"r3warn1", "r3warn0"}))
 
 			return expectedErr
@@ -588,7 +590,9 @@ var _ = Describe("Reporter", func() {
 
 		expectedValidateSeparateWarn := func() error {
 			var expectedWarn error
+			expectedWarn = multierror.Append(expectedWarn, errors.Errorf("WARN: \n  %v", []string{"r0warn1"}))
 			expectedWarn = multierror.Append(expectedWarn, errors.Errorf("WARN: \n  %v", []string{"r1warn1", "r1warn2"}))
+			expectedWarn = multierror.Append(expectedWarn, errors.Errorf("WARN: \n  %v", []string{"r4warn1", "r4warn0"}))
 			expectedWarn = multierror.Append(expectedWarn, errors.Errorf("WARN: \n  %v", []string{"r3warn1", "r3warn0"}))
 
 			return expectedWarn

--- a/pkg/api/v2/reporter/reporter_test.go
+++ b/pkg/api/v2/reporter/reporter_test.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/solo-io/go-utils/contextutils"
 	"github.com/solo-io/solo-kit/test/matchers"
 
 	"github.com/solo-io/solo-kit/pkg/utils/statusutils"
 
 	"github.com/golang/mock/gomock"
-	"github.com/hashicorp/go-multierror"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
@@ -483,5 +483,170 @@ var _ = Describe("Reporter", func() {
 			err := reporter.WriteReports(ctx, resourceErrs, nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
+	})
+
+})
+
+var _ = Describe("Reporter", func() {
+	type expectedReports struct {
+		Validation             func() error
+		StrictValidation       func() error
+		SeparateValidationErr  func() error
+		SeparateValidationWarn func() error
+	}
+
+	var (
+		mockResourceClient, mockResourceClient2, mockResourceClient3 clients.ResourceClient
+	)
+
+	BeforeEach(func() {
+		mockResourceClient = memory.NewResourceClient(memory.NewInMemoryResourceCache(), &v1.MockResource{})
+		mockResourceClient2 = memory.NewResourceClient(memory.NewInMemoryResourceCache(), &v1.MockResource{})
+		mockResourceClient3 = memory.NewResourceClient(memory.NewInMemoryResourceCache(), &v1.MockResource{})
+		// By default, DisableTruncateStatus is false, unless users opt into it
+		// To mirror that in our tests, we explicitly set it to false unless a test requires it
+		rep.DisableTruncateStatus = false
+	})
+
+	Context("Validation", func() {
+		var (
+			r1, r2, r3, r4, r5 resources.Resource
+		)
+		initResources := func() {
+			var err error
+			r1, err = mockResourceClient.Write(v1.NewMockResource("test-ns", "testres1"), clients.WriteOpts{})
+			Expect(err).NotTo(HaveOccurred())
+			r2, err = mockResourceClient.Write(v1.NewMockResource("test-ns", "testres2"), clients.WriteOpts{})
+			Expect(err).NotTo(HaveOccurred())
+			r3, err = mockResourceClient.Write(v1.NewMockResource("test-ns", "testres3"), clients.WriteOpts{})
+			Expect(err).NotTo(HaveOccurred())
+			r4, err = mockResourceClient2.Write(v1.NewMockResource("test-ns", "testres1"), clients.WriteOpts{})
+			Expect(err).NotTo(HaveOccurred())
+			r5, err = mockResourceClient3.Write(v1.NewMockResource("test-ns", "testres1"), clients.WriteOpts{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(r1).NotTo(BeNil())
+			Expect(r2).NotTo(BeNil())
+			Expect(r3).NotTo(BeNil())
+			Expect(r4).NotTo(BeNil())
+			Expect(r5).NotTo(BeNil())
+			Expect(r3).NotTo(BeNil())
+		}
+
+		// r0, r4, and r1 are all for the same resource key
+		// though the errors are sorted, the `r1` errors come after the `r4` errors because the errors
+		// are multierrors and when compared, are sorted by the number of errors contaiend.
+		// `r1` has 3 errors, so comes after `r0` and `r4`, which have one each.
+		validateReports := func() rep.ResourceReports {
+			return rep.ResourceReports{
+				r1.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r1err1"), fmt.Errorf("r1err2"), fmt.Errorf("r1err0")}}, Warnings: []string{"r1warn1", "r1warn2"}},
+				r2.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r2err1")}}},
+				r3.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r3err1")}}, Warnings: []string{"r3warn1", "r3warn0"}},
+				r4.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r4err1")}}},
+				r5.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r0err1")}}},
+			}
+		}
+
+		validateReportsReordered := func() rep.ResourceReports {
+			return rep.ResourceReports{
+				r5.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r0err1")}}},
+				r4.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r4err1")}}},
+				r3.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r3err1")}}, Warnings: []string{"r3warn1", "r3warn0"}},
+				r2.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r2err1")}}},
+				r1.(*v1.MockResource): rep.Report{Errors: &multierror.Error{Errors: []error{fmt.Errorf("r1err1"), fmt.Errorf("r1err2"), fmt.Errorf("r1err0")}}, Warnings: []string{"r1warn1", "r1warn2"}},
+			}
+		}
+
+		expectedValidateErrors := func() error {
+			var expectedErr error
+			expectedErr = multierror.Append(expectedErr, errors.Errorf("invalid resource test-ns.testres1"))
+			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r0err1"))
+			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r4err1"))
+			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r1err1"))
+			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r1err2"))
+			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r1err0"))
+			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r2err1"))
+			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r3err1"))
+
+			return expectedErr
+		}
+
+		expectedValidateStrictErrors := func() error {
+			var expectedErr error
+			expectedErr = multierror.Append(expectedErr, errors.Errorf("invalid resource test-ns.testres1"))
+			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r0err1"))
+			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r4err1"))
+			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r1err1"))
+			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r1err2"))
+			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r1err0"))
+			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r2err1"))
+			expectedErr = multierror.Append(expectedErr, fmt.Errorf("r3err1"))
+			expectedErr = multierror.Append(expectedErr, errors.Errorf("WARN: \n  %v", []string{"r1warn1", "r1warn2"}))
+			expectedErr = multierror.Append(expectedErr, errors.Errorf("WARN: \n  %v", []string{"r3warn1", "r3warn0"}))
+
+			return expectedErr
+		}
+
+		expectedValidateSeparateWarn := func() error {
+			var expectedWarn error
+			expectedWarn = multierror.Append(expectedWarn, errors.Errorf("WARN: \n  %v", []string{"r1warn1", "r1warn2"}))
+			expectedWarn = multierror.Append(expectedWarn, errors.Errorf("WARN: \n  %v", []string{"r3warn1", "r3warn0"}))
+
+			return expectedWarn
+		}
+
+		nilError := func() error { return nil }
+
+		BeforeEach(func() {
+			initResources()
+		})
+
+		// Run these tests multiple times to ensure that the validation errors are ordered consistently
+		DescribeTable("Validation functions should return the expected reports for a set of reports", MustPassRepeatedly(5), func(getReports func() rep.ResourceReports, expectedResults expectedReports) {
+			reports := getReports()
+			// Validate - Regular validation
+			err := reports.Validate()
+			Expect(err.Error()).To(Equal(expectedResults.Validation().Error()))
+
+			// ValidateStrict - Strict validation
+			err = reports.ValidateStrict()
+			Expect(err.Error()).To(Equal(expectedResults.StrictValidation().Error()))
+
+			// ValidateSeparateWarnings - Separate validation
+			var warnings error
+			err, warnings = reports.ValidateSeparateWarnings()
+			Expect(err.Error()).To(Equal(expectedResults.SeparateValidationErr().Error()))
+			Expect(warnings.Error()).To(Equal(expectedResults.SeparateValidationWarn().Error()))
+
+		},
+			Entry("validate reports", validateReports, expectedReports{
+				Validation:             expectedValidateErrors,
+				StrictValidation:       expectedValidateStrictErrors,
+				SeparateValidationErr:  expectedValidateErrors,
+				SeparateValidationWarn: expectedValidateSeparateWarn,
+			}),
+			Entry("validate reordered reports", validateReportsReordered, expectedReports{
+				Validation:             expectedValidateErrors,
+				StrictValidation:       expectedValidateStrictErrors,
+				SeparateValidationErr:  expectedValidateErrors,
+				SeparateValidationWarn: expectedValidateSeparateWarn,
+			}),
+		)
+
+		// No need to test against the reordered reports - that has already been tessted. This test is to ensure ValdiateWithWarnings calls the
+		// expected underlying Validation function
+		DescribeTable("ValidateWithWarnings should return the expected reports", func(warningHandling rep.WarningHandling, expectedErr func() error, expectedWarn func() error) {
+			err, warnings := validateReports().ValidateWithWarnings(warningHandling)
+			Expect(err.Error()).To(Equal(expectedErr().Error()))
+			if expectedWarn() == nil {
+				Expect(warnings).To(BeNil())
+			} else {
+				Expect(warnings.Error()).To(Equal(expectedWarn().Error()))
+			}
+		},
+			Entry("Strict warning handling", rep.Strict, expectedValidateStrictErrors, nilError),
+			Entry("IgnoreWarnings warning handling", rep.IgnoreWarnings, expectedValidateErrors, nilError),
+			Entry("SeparateWarnings warning handling", rep.SeparateWarnings, expectedValidateErrors, expectedValidateSeparateWarn),
+		)
+
 	})
 })


### PR DESCRIPTION
# Description
* Updated all Validation functions to return errors and warnings in a consistent order
* Added tests

# Context:
`ResourceReports` is defined as `type ResourceReports map[resources.InputResource]Report`

We want to present the results of iterating over these reports in a consistent manner, and the difficulty is that while the `InputResource`s may have unique instantiations, their underlying data might be identical.

The existing implementation does not guarantee any order, so updating to use a specific order will be backwards compatible.

# Details:
The approach taken to ensure output consistency is:
* initialize 2 data structures:
  * `refKeys []string` - a slice of the unique keys
  * `refMap = map[string][]resources.InputResource` - a map of the keys to the InputResources that are identified by that key.
* loop over the ResourceReports and for each key `res`, which is an InputResource:
  * `resKey := res.GetMetadata().Ref().String()` as the key for the resource 
  * add the `resKey` to `refKeys`
  * add the resource `res` to the slice of resources at `refMap[resKey]`
* Sort the `refKeys` array

We can now loop over `refKeys` and access the resources in a consistent order. We still need to handle the ordering of resources that share a key, and we will do that in the individual validation functions.

In the validation functions:
* loop over the sorted keys in `refKeys`
* for each key, loop over the associated resources
  * for each resource, look up the report and append the errors/warnings to a slice
  * after processing the reports for a given key, there will be a slice of errors
    * this is a 1d slice, as the errors from each report will be contained in a single multierror
  * sort this array
  * append the elements of the sorted array of errors to the running error.

By executing this process, we can say for a given set of reports:
* The resources will be iterated over in groups ordered by `res.GetMetadata().Ref().String()`
* Within the groups of the resources the sets of errors will sorted
* Because of this the sorting will be consistent each time Validation is run

## Interesting decisions
There is an existing idiosyncrasy of the error reporting where an "invalid resource" error is added only the first resource encountered with an error: https://github.com/solo-io/solo-kit/blob/2f0d239abcbc7ef5a8fdc756a3a68e27eb0f9ab9/pkg/api/v2/reporter/reporter.go#L201 . This means if there are multiple resources with errors, only one will generate an  "invalid resource" error.

This behavior has been maintained in the interest of rapid development
