### PR TITLE
Fix duplicate definition of predicate

### DIFF
--- a/changelog/v0.35.4/fix-duplicate-predicate.yaml
+++ b/changelog/v0.35.4/fix-duplicate-predicate.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/9274
+  resolvesIssue: false
+  description: Fixes the issue of multiple declarations of Predicate when multiple snapshots are generated
+

--- a/pkg/api/v1/resources/core/metadata_extensions.go
+++ b/pkg/api/v1/resources/core/metadata_extensions.go
@@ -17,3 +17,5 @@ func (m *Metadata) Ref() *ResourceRef {
 func (m *Metadata) Match(ref *ResourceRef) bool {
 	return m.GetNamespace() == ref.GetNamespace() && m.GetName() == ref.GetName()
 }
+
+type Predicate func(metadata *Metadata) bool

--- a/pkg/code-generator/codegen/templates/snapshot_template.go
+++ b/pkg/code-generator/codegen/templates/snapshot_template.go
@@ -114,9 +114,7 @@ func (s *{{ .GoName }}Snapshot) RemoveFromResourceList(resource resources.Resour
 	}
 }
 
-type Predicate func(metadata *core.Metadata) bool
-
-func (s *{{ .GoName }}Snapshot) RemoveMatches(predicate Predicate) {
+func (s *{{ .GoName }}Snapshot) RemoveMatches(predicate core.Predicate) {
 {{- range .Resources }}
 	var {{ upper_camel .PluralName }} {{ .ImportPrefix }}{{ .Name }}List
 	for _, res := range s.{{ upper_camel .PluralName }} {

--- a/test/mocks/v1/testing_snapshot.sk.go
+++ b/test/mocks/v1/testing_snapshot.sk.go
@@ -258,9 +258,7 @@ func (s *TestingSnapshot) RemoveFromResourceList(resource resources.Resource) er
 	}
 }
 
-type Predicate func(metadata *core.Metadata) bool
-
-func (s *TestingSnapshot) RemoveMatches(predicate Predicate) {
+func (s *TestingSnapshot) RemoveMatches(predicate core.Predicate) {
 	var Simplemocks SimpleMockResourceList
 	for _, res := range s.Simplemocks {
 		if matches := predicate(res.GetMetadata()); !matches {

--- a/test/mocks/v1alpha1/testing_snapshot.sk.go
+++ b/test/mocks/v1alpha1/testing_snapshot.sk.go
@@ -81,9 +81,7 @@ func (s *TestingSnapshot) RemoveFromResourceList(resource resources.Resource) er
 	}
 }
 
-type Predicate func(metadata *core.Metadata) bool
-
-func (s *TestingSnapshot) RemoveMatches(predicate Predicate) {
+func (s *TestingSnapshot) RemoveMatches(predicate core.Predicate) {
 	var Mocks MockResourceList
 	for _, res := range s.Mocks {
 		if matches := predicate(res.GetMetadata()); !matches {

--- a/test/mocks/v2alpha1/testing_snapshot.sk.go
+++ b/test/mocks/v2alpha1/testing_snapshot.sk.go
@@ -137,9 +137,7 @@ func (s *TestingSnapshot) RemoveFromResourceList(resource resources.Resource) er
 	}
 }
 
-type Predicate func(metadata *core.Metadata) bool
-
-func (s *TestingSnapshot) RemoveMatches(predicate Predicate) {
+func (s *TestingSnapshot) RemoveMatches(predicate core.Predicate) {
 	var Mocks MockResourceList
 	for _, res := range s.Mocks {
 		if matches := predicate(res.GetMetadata()); !matches {


### PR DESCRIPTION
Fixes the issue of multiple declarations of Predicate when multiple snapshots are generated

This causes compilation issues after running codegen on the latest v0.35.x