### PR TITLE
Makefile: Fix the install-protoc target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,10 @@ install-protoc:
 	if [ $(shell ${DEPSGOBIN}/protoc --version | grep -c ${PROTOC_VERSION}) -ne 0 ]; then \
 		echo expected protoc version ${PROTOC_VERSION} already installed ;\
 	else \
-		if [ "$(shell uname)" == "Darwin" ]; then \
+		if [ "$(shell uname)" = "Darwin" ]; then \
 			echo "downloading protoc for osx" ;\
 			wget $(PROTOC_URL)-osx-x86_64.zip -O $(DEPSGOBIN)/protoc-${PROTOC_VERSION}.zip ;\
-		elif [ "$(shell uname -m)" == "aarch64" ]; then \
+		elif [ "$(shell uname -m)" = "aarch64" ]; then \
 			echo "downloading protoc for linux aarch64" ;\
 			wget $(PROTOC_URL)-linux-aarch_64.zip -O $(DEPSGOBIN)/protoc-${PROTOC_VERSION}.zip ;\
 		else \

--- a/changelog/v0.36.1/fix-protoc-target.yaml
+++ b/changelog/v0.36.1/fix-protoc-target.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: >-
+    Fix the "install-protoc" Makefile target.


### PR DESCRIPTION
Quick cleanup PR to fix the install-protoc Makefile target that was introduced recently.

Here's the before output:

<details>

```bash
$ make install-protoc                  
/bin/sh: 1: /work/solo-kit/_output/.bin/protoc: not found
mkdir -p /work/solo-kit/_output/.bin
if [ 0 -ne 0 ]; then \
	echo expected protoc version 3.6.1 already installed ;\
else \
	if [ "Linux" == "Darwin" ]; then \
		echo "downloading protoc for osx" ;\
		wget https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-osx-x86_64.zip -O /work/solo-kit/_output/.bin/protoc-3.6.1.zip ;\
	elif [ "aarch64" == "aarch64" ]; then \
		echo "downloading protoc for linux aarch64" ;\
		wget https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-aarch_64.zip -O /work/solo-kit/_output/.bin/protoc-3.6.1.zip ;\
	else \
		echo "downloading protoc for linux x86-64" ;\
		wget https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip -O /work/solo-kit/_output/.bin/protoc-3.6.1.zip ;\
	fi ;\
	unzip /work/solo-kit/_output/.bin/protoc-3.6.1.zip -d /work/solo-kit/_output/.bin/protoc-3.6.1 ;\
	mv /work/solo-kit/_output/.bin/protoc-3.6.1/bin/protoc /work/solo-kit/_output/.bin/protoc ;\
	chmod +x /work/solo-kit/_output/.bin/protoc ;\
	rm -rf /work/solo-kit/_output/.bin/protoc-3.6.1 /work/solo-kit/_output/.bin/protoc-3.6.1.zip ;\
fi
/bin/sh: 4: [: Linux: unexpected operator
/bin/sh: 7: [: aarch64: unexpected operator
downloading protoc for linux x86-64
--2024-09-20 16:00:18--  https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip
Resolving github.com (github.com)... 140.82.114.4
Connecting to github.com (github.com)|140.82.114.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/23357588/3394de3e-9410-11e8-8b63-9cb4584b6c97?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240920%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240920T160019Z&X-Amz-Expires=300&X-Amz-Signature=03ea5fca6487067ec76daf55e03f5e36052cb2243f05202dd76651af61c5ce96&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dprotoc-3.6.1-linux-x86_64.zip&response-content-type=application%2Foctet-stream [following]
--2024-09-20 16:00:19--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/23357588/3394de3e-9410-11e8-8b63-9cb4584b6c97?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240920%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240920T160019Z&X-Amz-Expires=300&X-Amz-Signature=03ea5fca6487067ec76daf55e03f5e36052cb2243f05202dd76651af61c5ce96&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dprotoc-3.6.1-linux-x86_64.zip&response-content-type=application%2Foctet-stream
Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.111.133, 185.199.108.133, 185.199.109.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.111.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1423451 (1.4M) [application/octet-stream]
Saving to: ‘/work/solo-kit/_output/.bin/protoc-3.6.1.zip’

/work/solo-kit/_output/.bin/prot 100%[=======================================================>]   1.36M  7.61MB/s    in 0.2s    

2024-09-20 16:00:19 (7.61 MB/s) - ‘/work/solo-kit/_output/.bin/protoc-3.6.1.zip’ saved [1423451/1423451]

Archive:  /work/solo-kit/_output/.bin/protoc-3.6.1.zip
   creating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/
   creating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/
   creating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/wrappers.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/field_mask.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/api.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/struct.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/descriptor.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/timestamp.proto  
   creating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/compiler/
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/compiler/plugin.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/empty.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/any.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/source_context.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/type.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/duration.proto  
   creating: /work/solo-kit/_output/.bin/protoc-3.6.1/bin/
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/bin/protoc  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/readme.txt
```

</details>

And the after output:

<details>

```bash
$ make install-protoc
/bin/sh: 1: /work/solo-kit/_output/.bin/protoc: not found
mkdir -p /work/solo-kit/_output/.bin
if [ 0 -ne 0 ]; then \
	echo expected protoc version 3.6.1 already installed ;\
else \
	if [ "Linux" = "Darwin" ]; then \
		echo "downloading protoc for osx" ;\
		wget https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-osx-x86_64.zip -O /work/solo-kit/_output/.bin/protoc-3.6.1.zip ;\
	elif [ "aarch64" = "aarch64" ]; then \
		echo "downloading protoc for linux aarch64" ;\
		wget https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-aarch_64.zip -O /work/solo-kit/_output/.bin/protoc-3.6.1.zip ;\
	else \
		echo "downloading protoc for linux x86-64" ;\
		wget https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip -O /work/solo-kit/_output/.bin/protoc-3.6.1.zip ;\
	fi ;\
	unzip /work/solo-kit/_output/.bin/protoc-3.6.1.zip -d /work/solo-kit/_output/.bin/protoc-3.6.1 ;\
	mv /work/solo-kit/_output/.bin/protoc-3.6.1/bin/protoc /work/solo-kit/_output/.bin/protoc ;\
	chmod +x /work/solo-kit/_output/.bin/protoc ;\
	rm -rf /work/solo-kit/_output/.bin/protoc-3.6.1 /work/solo-kit/_output/.bin/protoc-3.6.1.zip ;\
fi
downloading protoc for linux aarch64
--2024-09-20 16:00:34--  https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-aarch_64.zip
Resolving github.com (github.com)... 140.82.112.4
Connecting to github.com (github.com)|140.82.112.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/23357588/3366f5c8-9410-11e8-8703-575742375f78?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240920%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240920T160034Z&X-Amz-Expires=300&X-Amz-Signature=ed9e56910abbcc54f907f78e6a315bd1ea7dbb954b2eba02d0400c63cc33ceaa&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dprotoc-3.6.1-linux-aarch_64.zip&response-content-type=application%2Foctet-stream [following]
--2024-09-20 16:00:34--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/23357588/3366f5c8-9410-11e8-8703-575742375f78?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240920%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240920T160034Z&X-Amz-Expires=300&X-Amz-Signature=ed9e56910abbcc54f907f78e6a315bd1ea7dbb954b2eba02d0400c63cc33ceaa&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dprotoc-3.6.1-linux-aarch_64.zip&response-content-type=application%2Foctet-stream
Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.110.133, 185.199.108.133, 185.199.109.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.110.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1524236 (1.5M) [application/octet-stream]
Saving to: ‘/work/solo-kit/_output/.bin/protoc-3.6.1.zip’

/work/solo-kit/_output/.bin/prot 100%[=======================================================>]   1.45M  7.86MB/s    in 0.2s    

2024-09-20 16:00:35 (7.86 MB/s) - ‘/work/solo-kit/_output/.bin/protoc-3.6.1.zip’ saved [1524236/1524236]

Archive:  /work/solo-kit/_output/.bin/protoc-3.6.1.zip
   creating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/
   creating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/
   creating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/wrappers.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/field_mask.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/api.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/struct.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/descriptor.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/timestamp.proto  
   creating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/compiler/
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/compiler/plugin.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/empty.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/any.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/source_context.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/type.proto  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/include/google/protobuf/duration.proto  
   creating: /work/solo-kit/_output/.bin/protoc-3.6.1/bin/
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/bin/protoc  
  inflating: /work/solo-kit/_output/.bin/protoc-3.6.1/readme.txt
```

</details>