### PR TITLE
Update template_funcs.go

### DIFF
--- a/changelog/v0.36.2/no-external-links.yaml
+++ b/changelog/v0.36.2/no-external-links.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/solo-projects/issues/6768
+  resolvesIssue: false
+  description: >-
+    Update protobuf processing to no longer render links to locally hosted external API docs, as they are being removed.

--- a/pkg/code-generator/docgen/funcs/template_funcs.go
+++ b/pkg/code-generator/docgen/funcs/template_funcs.go
@@ -319,9 +319,11 @@ func linkForField(project *model.Project, docsOptions *options.DocsOptions) func
 				//return "", errors.Errorf("failed to get generated file path for proto %v in list %v", file.GetName(), project.Request.FileToGenerate)
 			}
 
-			// Don't link to external apis docs, as they will be deleted
-			if strings.HasPrefix(linkedFile, "github.com/solo-io/gloo/projects/gloo/api/external") {
-				return typeName, nil
+			// Skip links for packages that are configured to be skipped
+			for _, pkg := range docsOptions.RenderOptions.GetSkipLinksForPackages() {
+				if strings.HasPrefix(linkedFile, pkg) {
+					return typeName, nil
+				}
 			}
 
 			linkedFile = relativeFilename(forFile.GetName(), linkedFile)

--- a/pkg/code-generator/docgen/funcs/template_funcs.go
+++ b/pkg/code-generator/docgen/funcs/template_funcs.go
@@ -320,7 +320,7 @@ func linkForField(project *model.Project, docsOptions *options.DocsOptions) func
 			}
 
 			// Skip links for packages that are configured to be skipped
-			for _, pkg := range docsOptions.RenderOptions.GetSkipLinksForPackages() {
+			for _, pkg := range docsOptions.RenderOptions.GetSkipLinksForPathPrefixes() {
 				if strings.HasPrefix(linkedFile, pkg) {
 					return typeName, nil
 				}

--- a/pkg/code-generator/docgen/funcs/template_funcs.go
+++ b/pkg/code-generator/docgen/funcs/template_funcs.go
@@ -318,8 +318,13 @@ func linkForField(project *model.Project, docsOptions *options.DocsOptions) func
 				linkedFile = filepath.Base(file.GetName())
 				//return "", errors.Errorf("failed to get generated file path for proto %v in list %v", file.GetName(), project.Request.FileToGenerate)
 			}
-			linkedFile = relativeFilename(forFile.GetName(), linkedFile)
 
+			// Don't link to external apis docs, as they will be deleted
+			if strings.HasPrefix(linkedFile, "github.com/solo-io/gloo/projects/gloo/api/external") {
+				return typeName, nil
+			}
+
+			linkedFile = relativeFilename(forFile.GetName(), linkedFile)
 			if docsOptions.Output == options.Restructured {
 				linkText = ":ref:`message." + strings.TrimPrefix(field.GetTypeName(), ".") + "`"
 			} else {

--- a/pkg/code-generator/docgen/options/options.go
+++ b/pkg/code-generator/docgen/options/options.go
@@ -28,14 +28,16 @@ type DocsOptions struct {
 
 // RenderOptions provides options for rendering documentation
 type RenderOptions struct {
-	SkipLinksForPackages []string // when rendering markdown, do not attempt to link to these packages or their subpackages
+	// SkipLinksForPathPrefixes is a list of file path prefixes foofr APIs to which we should not be attempting to link
+	// For example: "github.com/solo-io/gloo/projects/gloo/api/external"
+	SkipLinksForPathPrefixes []string
 }
 
-func (o *RenderOptions) GetSkipLinksForPackages() []string {
+func (o *RenderOptions) GetSkipLinksForPathPrefixes() []string {
 	if o == nil {
 		return nil
 	}
-	return o.SkipLinksForPackages
+	return o.SkipLinksForPathPrefixes
 }
 
 const (

--- a/pkg/code-generator/docgen/options/options.go
+++ b/pkg/code-generator/docgen/options/options.go
@@ -28,7 +28,7 @@ type DocsOptions struct {
 
 // RenderOptions provides options for rendering documentation
 type RenderOptions struct {
-	// SkipLinksForPathPrefixes is a list of file path prefixes foofr APIs to which we should not be attempting to link
+	// SkipLinksForPathPrefixes is a list of file path prefixes of APIs to which we should not be attempting to link
 	// For example: "github.com/solo-io/gloo/projects/gloo/api/external"
 	SkipLinksForPathPrefixes []string
 }

--- a/pkg/code-generator/docgen/options/options.go
+++ b/pkg/code-generator/docgen/options/options.go
@@ -21,8 +21,21 @@ type HugoOptions struct {
 }
 
 type DocsOptions struct {
-	Output      DocsOutput
-	HugoOptions *HugoOptions
+	Output        DocsOutput
+	HugoOptions   *HugoOptions
+	RenderOptions *RenderOptions
+}
+
+// RenderOptions provides options for rendering documentation
+type RenderOptions struct {
+	SkipLinksForPackages []string // when rendering markdown, do not attempt to link to these packages or their subpackages
+}
+
+func (o *RenderOptions) GetSkipLinksForPackages() []string {
+	if o == nil {
+		return nil
+	}
+	return o.SkipLinksForPackages
 }
 
 const (


### PR DESCRIPTION
We are removing external API documentation from our docs, so we need to stop linking to them when generating docs from protobufs.

The current solution is to no longer render the link, as there are complications in programmatically determining the correct externally hosted documentation location and version.

Discussion with docs: https://solo-io-corp.slack.com/archives/C03MFATU265/p1731608037978029?thread_ts=1731598700.372589&cid=C03MFATU265

Example change when pulled into `gloo`:
before:
```
| `responseTransformation` | [.envoy.api.v2.filter.http.TransformationTemplate](../../../../external/envoy/extensions/transformation/transformation.proto.sk/#transformationtemplate) |  |
```

after
```
| `responseTransformation` | .envoy.api.v2.filter.http.TransformationTemplate |  |
```


Example usage: https://github.com/solo-io/gloo/pull/10065