### PR TITLE
Cherrypicking log level change from v0.36.x

### DIFF
--- a/changelog/v0.35.6/downgrade-log-level.yaml
+++ b/changelog/v0.35.6/downgrade-log-level.yaml
@@ -1,6 +1,6 @@
 changelog:
 - type: FIX
-  issueLink: https://github.com/kgateway-dev/kgateway/issues/8626
-  resolvesIssue: true
+  issueLink: https://github.com/solo-io/solo-projects/issues/7530
+  resolvesIssue: false
   description: >-
     Downgrade the level of message "respond open watch priority %d and index %d :%v with new version %q" to debug.

--- a/changelog/v0.36.4/downgrade-log-level.yaml
+++ b/changelog/v0.36.4/downgrade-log-level.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/kgateway-dev/kgateway/issues/8626
+  resolvesIssue: true
+  description: >-
+    Downgrade the level of message "respond open watch priority %d and index %d :%v with new version %q" to debug.

--- a/pkg/api/v1/control-plane/cache/simple.go
+++ b/pkg/api/v1/control-plane/cache/simple.go
@@ -159,7 +159,7 @@ func (cache *snapshotCache) SetSnapshot(node string, snapshot Snapshot) {
 			version := snapshot.GetResources(watch.Request.TypeUrl).Version
 			if version != watch.Request.VersionInfo {
 				if cache.log != nil {
-					cache.log.Infof("respond open watch priority %d and index %d :%v with new version %q", pi.Index, pi.Priority, watch.Request.ResourceNames, version)
+					cache.log.Debugf("respond open watch priority %d and index %d :%v with new version %q", pi.Index, pi.Priority, watch.Request.ResourceNames, version)
 				}
 
 				resources := snapshot.GetResources(watch.Request.TypeUrl).Items
@@ -273,7 +273,7 @@ func (cache *snapshotCache) CreateWatch(request Request) (chan Response, func())
 		priority := info.watches.Add(ResponseWatch{Request: request, Response: value})
 		info.mu.Unlock()
 		if cache.log != nil {
-			cache.log.Infof("open watch Priority Index %d and Element Index %d for %s%v from nodeID %q, version %q",
+			cache.log.Debugf("open watch Priority Index %d and Element Index %d for %s%v from nodeID %q, version %q",
 				priority.Priority, priority.Index, request.TypeUrl, request.ResourceNames, nodeID, request.VersionInfo)
 		}
 		return value, cache.cancelWatch(nodeID, priority)


### PR DESCRIPTION
After this I will cut a release (v0.35.6) and update Gloo v1.17.x to that version and cut a new v1.17.x version.

https://github.com/solo-io/solo-projects/issues/7530