### PR TITLE
Update anchor generation

### DIFF
--- a/changelog/v0.39.3/docs-anchor.yaml
+++ b/changelog/v0.39.3/docs-anchor.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/doctopus/issues/124
+  resolvesIssue: true
+  description: >-
+    Fix a bug where headings on the same doc page have the same anchor and hence do not work. Numbers anchors for the same headings sequentially.

--- a/pkg/code-generator/docgen/funcs/template_funcs.go
+++ b/pkg/code-generator/docgen/funcs/template_funcs.go
@@ -137,10 +137,20 @@ func toHeading(docsOptions *options.DocsOptions) func(format string, p *string) 
 	if docsOptions.Output == options.Hugo {
 		return printPointer
 	} else {
+		// Track anchor names to handle duplicates
+		anchorCounts := make(map[string]int)
 		//--> <a name="{{ printfptr "%v" .Name }}">{{ printfptr "%v" .Name }}</a>
 		return func(format string, p *string) string {
 			val := printPointer(format, p)
-			return "<a name=" + val + ">" + val + "</a>"
+			name := strings.ToLower(val)
+			anchorCounts[name]++
+			var anchorName string
+			if anchorCounts[name] > 1 {
+				anchorName = fmt.Sprintf("%s-%d", name, anchorCounts[name]-1)
+			} else {
+				anchorName = name
+			}
+			return "<a name=" + anchorName + ">" + val + "</a>"
 		}
 	}
 }
@@ -149,8 +159,15 @@ func toAnchorLink(docsOptions *options.DocsOptions) func(format string, p *strin
 	if docsOptions.Output != options.Hugo {
 		return printPointer
 	} else {
+		// Track anchor names to handle duplicates
+		anchorCounts := make(map[string]int)
 		return func(format string, p *string) string {
-			return strings.ToLower(printPointer(format, p))
+			name := strings.ToLower(printPointer(format, p))
+			anchorCounts[name]++
+			if anchorCounts[name] > 1 {
+				return fmt.Sprintf("%s-%d", name, anchorCounts[name]-1)
+			}
+			return name
 		}
 	}
 }


### PR DESCRIPTION
So that if there are duplicate anchors on the page, they are sequentially numbered. e.g.,
1. First time: OpenAI → #openai
2. Second time: OpenAI → #openai-1
3. Third time: OpenAI → #openai-2 and so on...

Context in Slack thread: https://solo-io-corp.slack.com/archives/C0520LDVD2Q/p1758237035410509
BOT NOTES: 
resolves https://github.com/solo-io/doctopus/issues/124

Tested this in the `gloo` repo by:

1. updating the `go.mod` file to point to my branch of solo-kit, by adding this replace at the end of the file: `replace github.com/solo-io/solo-kit => github.com/solo-io/solo-kit v0.39.3-0.20250919152847-fa661d993ca2`
2. running `make go-generate-all` to generate the API docs
3. checking the `ai.proto.sk.md` file, which as the anchors, e.g., `#openai-1` in the toc below

```

---
title: "Ai"
weight: 5
---

<!-- Code generated by solo-kit. DO NOT EDIT. -->


### Package: `ai.options.gloo.solo.io` 
**Types:**


- [SingleAuthToken](#singleauthtoken)
- [Passthrough](#passthrough-1)
- [UpstreamSpec](#upstreamspec)
- [PathOverride](#pathoverride)
- [CustomHost](#customhost)
- [OpenAI](#openai)
- [AzureOpenAI](#azureopenai)
- [Gemini](#gemini)
- [VertexAI](#vertexai)
- [Publisher](#publisher)
- [Mistral](#mistral)
- [Anthropic](#anthropic)
- [Bedrock](#bedrock)
- [AwsCredentialProvider](#awscredentialprovider)
- [AWSInline](#awsinline)
- [MultiPool](#multipool)
- [Backend](#backend)
- [Priority](#priority)
- [RouteSettings](#routesettings)
- [RouteType](#routetype)
- [FieldDefault](#fielddefault-1)
- [Postgres](#postgres)
- [Embedding](#embedding)
- [OpenAI](#openai-1)
- [AzureOpenAI](#azureopenai-1)
- [SemanticCache](#semanticcache)
- [Redis](#redis)
- [Weaviate](#weaviate)
- [DataStore](#datastore)
- [Mode](#mode-1)
- [RAG](#rag)
- [DataStore](#datastore-1)
- [AIPromptEnrichment](#aipromptenrichment)
- [Message](#message-1)
- [AIPromptGuard](#aipromptguard)
- [Regex](#regex)
- [RegexMatch](#regexmatch)
- [BuiltIn](#builtin)
- [Action](#action-3)
- [Webhook](#webhook)
- [HeaderMatch](#headermatch)
- [MatchType](#matchtype)
- [Moderation](#moderation)
- [OpenAI](#openai-2)
- [Request](#request-1)
- [CustomResponse](#customresponse)
- [Response](#response)
  
...
```