### PR TITLE
anchors in headings

### DIFF
--- a/changelog/v0.39.4/docs-anchor2.yaml
+++ b/changelog/v0.39.4/docs-anchor2.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/doctopus/issues/124
+  resolvesIssue: true
+  description: >-
+    Fix a bug where headings on the same doc page have the same anchor and hence do not work. Numbers anchors for the same headings sequentially. The headings were not getting numbered from the previous PR.

--- a/pkg/code-generator/docgen/funcs/template_funcs.go
+++ b/pkg/code-generator/docgen/funcs/template_funcs.go
@@ -135,7 +135,18 @@ func TemplateFuncs(project *model.Project, docsOptions *options.DocsOptions) tem
 
 func toHeading(docsOptions *options.DocsOptions) func(format string, p *string) string {
 	if docsOptions.Output == options.Hugo {
-		return printPointer
+		// For Hugo, we need to generate the same numbered anchors as toAnchorLink
+		// Track anchor names to handle duplicates
+		anchorCounts := make(map[string]int)
+		return func(format string, p *string) string {
+			val := printPointer(format, p)
+			name := strings.ToLower(val)
+			anchorCounts[name]++
+			if anchorCounts[name] > 1 {
+				return fmt.Sprintf("%s {#%s-%d}", val, name, anchorCounts[name]-1)
+			}
+			return fmt.Sprintf("%s {#%s}", val, name)
+		}
 	} else {
 		// Track anchor names to handle duplicates
 		anchorCounts := make(map[string]int)


### PR DESCRIPTION
followup to https://github.com/solo-io/solo-kit/pull/583, for https://github.com/solo-io/doctopus/issues/124, more context in [Slack](https://solo-io-corp.slack.com/archives/CE0R6KPS5/p1758298278068919)

Tested by doing this in the `gloo` repo:
1. Pull in my changes in this PR by running `go get github.com/solo-io/solo-kit@adb-anchors2`
2. `make generate-all -B`
3. example of changes in this commit: https://github.com/solo-io/gloo/commit/1c5105e992a09d6e1703164a8bc0f43d777a604c
BOT NOTES: 
resolves https://github.com/solo-io/doctopus/issues/124