### PR TITLE
Fix ADS watch retention when responses are suppressed

### DIFF
--- a/pkg/api/v1/control-plane/cache/cache_test.go
+++ b/pkg/api/v1/control-plane/cache/cache_test.go
@@ -1,6 +1,8 @@
 package cache_test
 
 import (
+	"time"
+
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -144,6 +146,61 @@ var _ = Describe("Control Plane Cache", func() {
 		// the cache will reset to empty version for missing resources
 		Expect(snap2.GetResources(types.ListenerTypeV3).Version).To(Equal(""))
 		Expect(snap2.GetResources(types.RouteTypeV3).Version).To(Equal(""))
+	})
+
+	It("retains ADS watches when immediate response is suppressed by resource-name mismatch", func() {
+		settings := cache.CacheSettings{
+			Ads:  true,
+			Hash: TestIDHash{},
+		}
+		c := cache.NewSnapshotCache(settings)
+		key := "test"
+
+		snapshotV1 := &TestSnapshot{
+			Endpoints: cache.NewResources("v1", []cache.Resource{
+				resource.NewEnvoyResource(makeEndpoint("a")),
+				resource.NewEnvoyResource(makeEndpoint("b")),
+			}),
+		}
+		c.SetSnapshot(key, snapshotV1)
+
+		respChan, cancel := c.CreateWatch(cache.Request{
+			TypeUrl:       types.EndpointTypeV3,
+			ResourceNames: []string{"a"},
+			VersionInfo:   "v0",
+			Node: &envoy_config_core_v3.Node{
+				Id: key,
+			},
+		})
+		defer cancel()
+
+		Consistently(respChan, 200*time.Millisecond, 20*time.Millisecond).ShouldNot(Receive())
+		Expect(c.GetStatusInfo(key).GetNumWatches()).To(Equal(1))
+
+		snapshotV2 := &TestSnapshot{
+			Endpoints: cache.NewResources("v2", []cache.Resource{
+				resource.NewEnvoyResource(makeEndpoint("a")),
+				resource.NewEnvoyResource(makeEndpoint("b")),
+			}),
+		}
+		c.SetSnapshot(key, snapshotV2)
+
+		Consistently(respChan, 200*time.Millisecond, 20*time.Millisecond).ShouldNot(Receive())
+		Expect(c.GetStatusInfo(key).GetNumWatches()).To(Equal(1))
+
+		snapshotV3 := &TestSnapshot{
+			Endpoints: cache.NewResources("v3", []cache.Resource{
+				resource.NewEnvoyResource(makeEndpoint("a")),
+			}),
+		}
+		c.SetSnapshot(key, snapshotV3)
+
+		var resp cache.Response
+		Eventually(respChan, time.Second, 20*time.Millisecond).Should(Receive(&resp))
+		Expect(resp.Version).To(Equal("v3"))
+		Expect(resp.Resources).To(HaveLen(1))
+		Expect(resp.Resources[0].Self().Name).To(Equal("a"))
+		Expect(c.GetStatusInfo(key).GetNumWatches()).To(Equal(0))
 	})
 
 })

--- a/pkg/api/v1/control-plane/cache/simple.go
+++ b/pkg/api/v1/control-plane/cache/simple.go
@@ -29,9 +29,11 @@ import (
 )
 
 var (
-	MResponses = stats.Int64("xds/responses", "The responses for envoy", "1")
+	MResponses           = stats.Int64("xds/responses", "The responses for envoy", "1")
+	MSuppressedResponses = stats.Int64("xds/suppressed_responses", "The responses intentionally suppressed by cache logic", "1")
 
-	KeyType = tag.MustNewKey("type")
+	KeyType   = tag.MustNewKey("type")
+	KeyReason = tag.MustNewKey("reason")
 
 	ResponsesView = &view.View{
 		Name:        "xds/responses",
@@ -42,6 +44,16 @@ var (
 			KeyType,
 		},
 	}
+	SuppressedResponsesView = &view.View{
+		Name:        "xds/suppressed_responses",
+		Measure:     MSuppressedResponses,
+		Description: "The times the cache intentionally withheld an xDS response",
+		Aggregation: view.Count(),
+		TagKeys: []tag.Key{
+			KeyType,
+			KeyReason,
+		},
+	}
 
 	VersionUpToDateError = errors.New("skip fetch: version up to date")
 
@@ -49,8 +61,10 @@ var (
 	_ SnapshotCache = new(snapshotCache)
 )
 
+const suppressedResponseReasonAdsNameMismatch = "ads_name_mismatch"
+
 func init() {
-	view.Register(ResponsesView)
+	view.Register(ResponsesView, SuppressedResponsesView)
 }
 
 // SnapshotCache is a snapshot-based cache that maintains a single versioned
@@ -168,10 +182,11 @@ func (cache *snapshotCache) SetSnapshot(node string, snapshot Snapshot) {
 				// empty resource - intended behavior is for the resources to be cleared
 				if resources != nil {
 					// snapshot has been initialized and exists
-					cache.respond(watch.Request, watch.Response, resources, version)
-
-					// discard the watch
-					watches.Delete(pi)
+					responded := cache.respond(watch.Request, watch.Response, resources, version)
+					if responded {
+						// discard the watch
+						watches.Delete(pi)
+					}
 				}
 			}
 		}
@@ -260,14 +275,7 @@ func (cache *snapshotCache) CreateWatch(request Request) (chan Response, func())
 	// allocate capacity 1 to allow one-time non-blocking use
 	value := make(chan Response, 1)
 
-	snapshot, exists := cache.snapshots[nodeID]
-	if snapshot == nil {
-		snapshot = NilSnapshot{}
-	}
-	version := snapshot.GetResources(request.TypeUrl).Version
-
-	// if the requested version is up-to-date or missing a response, leave an open watch
-	if !exists || request.VersionInfo == version {
+	addWatch := func() (chan Response, func()) {
 		info.mu.Lock()
 		// check SetSnapshot() for responses on the watches map
 		priority := info.watches.Add(ResponseWatch{Request: request, Response: value})
@@ -279,8 +287,25 @@ func (cache *snapshotCache) CreateWatch(request Request) (chan Response, func())
 		return value, cache.cancelWatch(nodeID, priority)
 	}
 
+	snapshot, exists := cache.snapshots[nodeID]
+	if snapshot == nil {
+		snapshot = NilSnapshot{}
+	}
+	version := snapshot.GetResources(request.TypeUrl).Version
+
+	// if the requested version is up-to-date or missing a response, leave an open watch
+	if !exists || request.VersionInfo == version {
+		return addWatch()
+	}
+
 	// otherwise, the watch may be responded immediately
-	cache.respond(request, value, snapshot.GetResources(request.TypeUrl).Items, version)
+	responded := cache.respond(request, value, snapshot.GetResources(request.TypeUrl).Items, version)
+	if !responded {
+		// In ADS mode, the response can be suppressed if requested names are not
+		// a superset of snapshot resources. Keep an open watch so a later snapshot
+		// update can still satisfy this request.
+		return addWatch()
+	}
 
 	return value, func() {
 		close(value)
@@ -306,7 +331,7 @@ func (cache *snapshotCache) cancelWatch(nodeID string, watchIndex PriorityIndex)
 
 // Respond to a watch with the snapshot value. The value channel should have capacity not to block.
 // TODO(kuat) do not respond always, see issue https://github.com/envoyproxy/go-control-plane/issues/46
-func (cache *snapshotCache) respond(request Request, value chan Response, resources map[string]Resource, version string) {
+func (cache *snapshotCache) respond(request Request, value chan Response, resources map[string]Resource, version string) bool {
 	// for ADS, the request names must match the snapshot names
 	// if they do not, then the watch is never responded, and it is expected that envoy makes another request
 	if len(request.ResourceNames) != 0 && cache.ads {
@@ -314,7 +339,11 @@ func (cache *snapshotCache) respond(request Request, value chan Response, resour
 			if cache.log != nil {
 				cache.log.Debugf("ADS mode: not responding to request: %v", err)
 			}
-			return
+			stats.RecordWithTags(context.TODO(), []tag.Mutator{
+				tag.Insert(KeyType, request.GetTypeUrl()),
+				tag.Insert(KeyReason, suppressedResponseReasonAdsNameMismatch),
+			}, MSuppressedResponses.M(1))
+			return false
 		}
 	}
 	if cache.log != nil {
@@ -325,6 +354,7 @@ func (cache *snapshotCache) respond(request Request, value chan Response, resour
 		tag.Insert(KeyType, request.GetTypeUrl()),
 	}, MResponses.M(1))
 	value <- createResponse(request, resources, version)
+	return true
 }
 
 func createResponse(request Request, resources map[string]Resource, version string) Response {


### PR DESCRIPTION
## Problem

In ADS mode, cache responses are intentionally suppressed when `request.resource_names` are not a superset of snapshot resources.

Before this change, suppressed responses could incorrectly drop the watch in two paths:

1. `CreateWatch()` immediate-response path:
- If a snapshot existed and the request version was stale, the cache attempted an immediate response.
- If ADS name matching suppressed that response, no watch was added to the watch set.
- Result: the request was effectively dropped and the client could miss later satisfiable updates.

2. `SetSnapshot()` watch replay path:
- Existing watches were deleted unconditionally after `respond(...)` was called.
- If ADS name matching suppressed the response, the watch was still removed.
- Result: same loss of liveness for that watch.

This creates a recurring out-of-sync condition where a client can stop receiving expected updates until another request lifecycle event occurs.

## Fix

### 1) Make `respond(...)` return whether it actually sent a response
- `respond(...)` now returns `bool`.
- Returns `false` when ADS name mismatch suppresses the response.
- Returns `true` only when a response is published to the watch channel.

### 2) Preserve watches when a response was suppressed
- In `SetSnapshot()`, delete a watch only if `respond(...) == true`.
- In `CreateWatch()`, if immediate response is suppressed, fall back to adding an open watch.

This ensures watches are retained and can be satisfied by later snapshots.

### 3) Add observability for intentional suppressions
- Added metric: `xds/suppressed_responses`.
- Tags:
  - `type` (xDS type URL)
  - `reason` (`ads_name_mismatch`)

This lets operators distinguish expected suppressions from delivery failures.

## Verification

### New unit test
Added: `retains ADS watches when immediate response is suppressed by resource-name mismatch` in `pkg/api/v1/control-plane/cache/cache_test.go`

Test flow:
1. Set snapshot `v1` with endpoints `a,b`.
2. Open ADS watch requesting only `a`, with stale version.
3. Verify no response is sent and watch count remains `1`.
4. Set `v2` still `a,b`; verify still no response and watch remains.
5. Set `v3` with only `a`; verify response is sent, version `v3`, 1 resource, and watch count becomes `0`.

### Solo-kit test runs
- `go test ./pkg/api/v1/control-plane/cache -count=1`
- `go test ./pkg/api/v1/control-plane/... -count=1`

### Cross-repo verification in gloo
Using a temporary `go.mod` replace in `gloo` to point to this local branch of `solo-kit`:
- `go test ./projects/gloo/pkg/xds ./projects/gloo/pkg/syncer/... -count=1`
- `go run /tmp/verify_ads_watch_repro.go`

Result: targeted `gloo` suites passed and repro harness reported:
- `PASS: ADS watch-retention fix works via gloo dependency graph`

## Notes

This change intentionally favors correctness/liveness by retaining suppressed watches instead of dropping them. Existing cancellation and watch lifecycle behavior remains in place; the new suppression metric provides visibility if suppressions accumulate.
