### PR TITLE
Bump proto gen timeout

### DIFF
--- a/changelog/v0.41.2/increase-protogen-timeout.yaml
+++ b/changelog/v0.41.2/increase-protogen-timeout.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/solo-projects/issues/8953
+    resolvesIssue: false
+    description: |
+      Increase timeout for code generation.

--- a/changelog/v0.41.2/increase-protogen-timeout.yaml
+++ b/changelog/v0.41.2/increase-protogen-timeout.yaml
@@ -3,4 +3,4 @@ changelog:
     issueLink: https://github.com/solo-io/solo-projects/issues/8953
     resolvesIssue: false
     description: |
-      Increase timeout for code generation.
+      Increase timeout for code generation

--- a/changelog/v0.41.2/increase-protogen-timeout.yaml
+++ b/changelog/v0.41.2/increase-protogen-timeout.yaml
@@ -3,4 +3,4 @@ changelog:
     issueLink: https://github.com/solo-io/solo-projects/issues/8953
     resolvesIssue: false
     description: |
-      Increase timeout for code generation
+      Increase timeout for code generation.

--- a/pkg/code-generator/collector/extractor.go
+++ b/pkg/code-generator/collector/extractor.go
@@ -87,7 +87,7 @@ func (i *synchronizedImportsExtractor) FetchImportsForFile(protoFile string, imp
 	i.activeRequestsMu.Unlock()
 
 	select {
-	case <-time.After(45 * time.Second):
+	case <-time.After(90 * time.Second):
 		// We should never reach this. This can only occur if we deadlock on file imports
 		// which only happens with cyclic dependencies or golang is being very slow.
 		// The deadlock occurs on file imports with cyclic dependencies.

--- a/pkg/code-generator/collector/extractor.go
+++ b/pkg/code-generator/collector/extractor.go
@@ -87,7 +87,7 @@ func (i *synchronizedImportsExtractor) FetchImportsForFile(protoFile string, imp
 	i.activeRequestsMu.Unlock()
 
 	select {
-	case <-time.After(15 * time.Second):
+	case <-time.After(45 * time.Second):
 		// We should never reach this. This can only occur if we deadlock on file imports
 		// which only happens with cyclic dependencies or golang is being very slow.
 		// The deadlock occurs on file imports with cyclic dependencies.


### PR DESCRIPTION
Hitting this on an older M1 laptop. Check Point Endpoint Security may be playing a role in the slowness.
